### PR TITLE
Fixed incorrect URI schema

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,8 +62,8 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 <div id="error"></div>
                 <div id="container"></div>
             </body>
-            <script src="${this.getResourcePath('jquery.min.js')}"></script>
-            <script src="${this.getResourcePath('three.min.js')}"></script>
+            <script src="file://${this.getResourcePath('jquery.min.js')}"></script>
+            <script src="file://${this.getResourcePath('three.min.js')}"></script>
             <canvas id="canvas"></canvas>
             <script id="vs" type="x-shader/x-vertex">
                 void main() {


### PR DESCRIPTION
There was an issue with the URI schema when loading the resource scripts, which is supposedly what caused the extension not to work.
By forcing it to use `file://`, this issue is now resolved. 
This should solve issues #10 and  #9.