### PR TITLE
Adding a number of features

### DIFF
--- a/demos/blending.glsl
+++ b/demos/blending.glsl
@@ -1,0 +1,12 @@
+#iChannel0 https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg
+#iChannel1 https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/Sony_Alpha_logo.svg/1200px-Sony_Alpha_logo.svg.png
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / iResolution.xy;
+
+    vec3 pattern = texture2D(iChannel0, uv).rgb;
+    float mask = texture2D(iChannel1, uv).a;
+
+    vec3 maskedPattern = pattern * mask;
+    gl_FragColor = vec4(maskedPattern, 1.0);
+}

--- a/demos/metaballs.glsl
+++ b/demos/metaballs.glsl
@@ -172,7 +172,7 @@ void main()
 {
 	vec2 uv = gl_FragCoord.xy / iResolution.xy - 0.5;
 	uv.x *= iResolution.x/iResolution.y; //fix aspect ratio
-	vec3 mouse = vec3(0.);
+	vec2 mouse = iMouse.xy / iResolution.xy;
 	
 	float t = iGlobalTime*.5*object_speed_modifier + 2.0;
 	

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
 
         // http://threejs.org/docs/api/renderers/webgl/WebGLProgram.html
-        const line_offset = 113;
+        const line_offset = 117;
         const content = `
             <head>
             <style>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         let shader = vscode.window.activeTextEditor.document.getText();
         const config = vscode.workspace.getConfiguration('shader-toy');
 
-        var line_offset = 117;
+        var line_offset = 120;
 
         let textureScript = "\n";
         if (config.get('useInShaderTextures', false)) {
@@ -139,6 +139,9 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 uniform sampler2D   iChannel7;
                 uniform sampler2D   iChannel8;
                 uniform sampler2D   iChannel9;
+
+                #define SHADER_TOY
+
                 ${shader}
             </script>
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,9 +58,9 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
         let textureScript = "\n";
         if (config.get('useInShaderTextures', false)) {
-            var texturePos = shader.indexOf("#Channel", 0);
+            var texturePos = shader.indexOf("#iChannel", 0);
             while (texturePos >= 0) {
-                var channelPos = texturePos + 8;
+                var channelPos = texturePos + 9;
                 var channel = parseInt(shader.charAt(channelPos));
                 var endlinePos = shader.indexOf("\n", texturePos);
                 let texture = shader.substr(channelPos + 2, endlinePos - channelPos - 3);
@@ -69,7 +69,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 line_offset--;
 
                 shader = shader.replace(shader.substring(texturePos, endlinePos + 1), "");
-                texturePos = shader.indexOf("#Channel", texturePos);
+                texturePos = shader.indexOf("#iChannel", texturePos);
             }
         }
         else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,12 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 uniform sampler2D   iChannel1;
                 uniform sampler2D   iChannel2;
                 uniform sampler2D   iChannel3;
+                uniform sampler2D   iChannel4;
+                uniform sampler2D   iChannel5;
+                uniform sampler2D   iChannel6;
+                uniform sampler2D   iChannel7;
+                uniform sampler2D   iChannel8;
+                uniform sampler2D   iChannel9;
                 ${shader}
             </script>
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,8 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         let shader = vscode.window.activeTextEditor.document.getText();
         const config = vscode.workspace.getConfiguration('shader-toy');
 
+        var line_offset = 117;
+
         let textureScript = "\n";
         if (config.get('useInShaderTextures', false)) {
             var texturePos = shader.indexOf("#Channel", 0);
@@ -64,6 +66,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 let texture = shader.substr(channelPos + 2, endlinePos - channelPos - 3);
 
                 textureScript += `shader.uniforms.iChannel${channel} = { type: 't', value: THREE.ImageUtils.loadTexture('${texture}') };\n`;
+                line_offset--;
 
                 shader = shader.replace(shader.substring(texturePos, endlinePos + 1), "");
                 texturePos = shader.indexOf("#Channel", texturePos);
@@ -87,7 +90,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
 
         // http://threejs.org/docs/api/renderers/webgl/WebGLProgram.html
-        const line_offset = 117;
         const content = `
             <head>
             <style>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
 
         // http://threejs.org/docs/api/renderers/webgl/WebGLProgram.html
-        const line_offset = 27;
+        const line_offset = 113;
         const content = `
             <head>
             <style>
@@ -148,7 +148,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         camera.updateProjectionMatrix();
                         resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
                     }
-                    
+
                     
                     shader.uniforms['iResolution'].value = resolution;
                     shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ export function activate(context: ExtensionContext) {
     let previewUri = Uri.parse('glsl-preview://authority/glsl-preview');
     let provider = new GLSLDocumentContentProvider(context);
     let registration = vscode.workspace.registerTextDocumentContentProvider('glsl-preview', provider);
+    const config = vscode.workspace.getConfiguration('shader-toy');
     var _timeout: number;
 
     vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
@@ -21,6 +22,13 @@ export function activate(context: ExtensionContext) {
             }
         }, 1000);
     });
+    if (config.get('reloadOnChangeEditor', false)) {
+        vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor) => {
+            if(e && e.document === e.document) {
+                provider.update(previewUri);
+            }
+        });
+    }
     let disposable = vscode.commands.registerCommand('extension.showGlslPreview', () => {
         return vscode.commands.executeCommand('vscode.previewHtml', previewUri, ViewColumn.Two, 'GLSL Preview')
         .then((success) => {}, (reason) => { vscode.window.showErrorMessage(reason); });
@@ -45,7 +53,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
     public provideTextDocumentContent(uri: Uri): string {
         const shader = vscode.window.activeTextEditor.document.getText();
         const config = vscode.workspace.getConfiguration('shader-toy');
-        const has_textures = 'textures' in vscode.workspace.getConfiguration('shader-toy');
         let textures = config['textures'] || {};
         let textureScript = "";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,7 +233,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             </script>
             </body>
         `;
-        console.log(content);
+        // console.log(content);
         return content;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ export function activate(context: ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
         clearTimeout(_timeout);
         _timeout = setTimeout( function() { 
-            if(e.document === vscode.window.activeTextEditor.document) {
+            if(vscode.window.activeTextEditor && e.document === vscode.window.activeTextEditor.document) {
                 provider.update(previewUri);
             }
         }, 1000);
@@ -87,9 +87,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 uniform sampler2D   iChannel1;
                 uniform sampler2D   iChannel2;
                 uniform sampler2D   iChannel3;
-//                  uniform vec4        iDate;
-//                  uniform float       iSampleRate;
-                
                 ${shader}
             </script>
 
@@ -148,7 +145,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         camera.updateProjectionMatrix();
                         resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
                     }
-
                     
                     shader.uniforms['iResolution'].value = resolution;
                     shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();
@@ -158,6 +154,25 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
                     renderer.render(scene, camera);
                 }
+                canvas.addEventListener('mousemove', function(evt) {
+                    if (mouse.z + mouse.w != 0) {
+                        var rect = canvas.getBoundingClientRect();
+                        mouse.x = evt.clientX - rect.left;
+                        mouse.y = resolution.y - evt.clientY - rect.top;
+                    } 
+                }, false);
+                canvas.addEventListener('mousedown', function(evt) {
+                    if (evt.button == 0)
+                        mouse.z = 1;
+                    if (evt.button == 2)
+                        mouse.w = 1;
+                }, false);
+                canvas.addEventListener('mouseup', function(evt) {
+                    if (evt.button == 0)
+                        mouse.z = 0;
+                    if (evt.button == 2)
+                        mouse.w = 0;
+                }, false);
             </script>
             </body>
         `;

--- a/src/preview.html
+++ b/src/preview.html
@@ -33,7 +33,9 @@
         uniform sampler2D   iChannel6;
         uniform sampler2D   iChannel7;
         uniform sampler2D   iChannel8;
-        uniform sampler2D   iChannel9;              
+        uniform sampler2D   iChannel9;      
+
+        #define SHADER_TOY        
                                 
         void main() {
             gl_FragColor = vec4(1., 0., 0., 1.0);
@@ -59,7 +61,7 @@
             console.error = function (message) {
                 if('7' in arguments) {
                     $("#message").html("<h3>Shader failed to compile</h3><ul>")                                    
-                    $("#message").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 117); }));
+                    $("#message").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 120); }));
                     $("#message").append("</ul>");
                 }
             };

--- a/src/preview.html
+++ b/src/preview.html
@@ -1,106 +1,120 @@
-              <head>
-            <style>
-                html, body, #canvas { margin: 0; padding: 0; width: 100%; height: 100%; display: block; }
-                #error {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold;}
-            </style>
-            </head>
-            <body>
-                <div id="error"></div>
-                <div id="container"></div>
+<head>
+    <style>
+        html, body, #canvas { margin: 0; padding: 0; width: 100%; height: 100%; display: block; }
+        #error {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold;}
+    </style>
+</head>
+<body>
+    <div id="error"></div>
+    <div id="container"></div>
 
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/84/three.min.js"></script>              
-                <canvas id="canvas"></canvas>
-                <script id="vs" type="x-shader/x-vertex">
-                    void main() {
-                        gl_Position = vec4(position, 1.0);
-                    }
-                </script>
-                <script id="fs" type="x-shader/x-fragment">
-                    uniform vec3        iResolution;
-                    uniform float       iGlobalTime;
-                    uniform float       iTimeDelta;
-                    uniform int         iFrame;
-                    uniform float       iChannelTime[4];
-                    uniform vec3        iChannelResolution[4];
-                    uniform vec4        iMouse;
-                    uniform sampler2D   iChannel0;
-                    uniform sampler2D   iChannel1;
-                    uniform sampler2D   iChannel2;
-                    uniform sampler2D   iChannel3;
-    //                  uniform vec4        iDate;
-    //                  uniform float       iSampleRate;                           
-                                            
-                    void main() {
-
-        gl_FragColor = vec4(1., 0., 0., 1.0);
-
-    }
-                </script>
-                <script type="text/javascript">
-                    (function(){
-                        console.error = function (message) {
-                            if('7' in arguments) {
-                                $("#error").html("<h3>Shader failed to compile</h3><ul>")                                    
-                                $("#error").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
-                                $("#error").append("</ul>");
-                            }
-                        };
-                    })();
-                    var canvas = document.getElementById('canvas');
-                    var scene = new THREE.Scene();
-                    var renderer = new THREE.WebGLRenderer({canvas: canvas, antialias: true});
-                    var camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientWidth, 1, 1000);
-                    var clock = new THREE.Clock();
-                    var resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
-                    var channelResolution = new THREE.Vector3(128.0, 128.0, 0.0);
-                    var mouse = new THREE.Vector4(0, 0, 0, 0);
-                    var shader = new THREE.ShaderMaterial({
-                            vertexShader: document.getElementById('vs').textContent,
-                            fragmentShader: document.getElementById('fs').textContent,
-                            depthWrite: false,
-                            depthTest: false,
-                            uniforms: {
-                                iResolution: { type: "v3", value: resolution },
-                                iGlobalTime: { type: "f", value: 0.0 },
-                                iTimeDelta: { type: "f", value: 0.0 },
-                                iFrame: { type: "i", value: 0 },
-                                iChannelTime: { type: "fv1", value: [0., 0., 0., 0.] }, 
-                                iChannelResolution: { type: "v3v", value:
-                                    [channelResolution, channelResolution, channelResolution, channelResolution]   
-                                },
-                                iMouse: { type: "v4", value: mouse },
-                            }
-                        });
-                    if(true) {
-                        shader.uniforms.iChannel0 = { type: 't', value: THREE.ImageUtils.loadTexture("https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg") };
-                        Function.prototype;
-                        Function.prototype;
-                        Function.prototype;
-                    }
-                    var quad = new THREE.Mesh(
-                        new THREE.PlaneGeometry(2, 2),
-                        shader
-                    );
-                    scene.add(quad);
-                    camera.position.z = 10;
-                    render();
-                    function render() {
-                        requestAnimationFrame(render);
-                        if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
-                            renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
-                            camera.aspect = canvas.clientWidth /  canvas.clientHeight;
-                            camera.updateProjectionMatrix();
-                            resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
-                        }
-                        
-                        
-                        shader.uniforms['iResolution'].value = resolution;
-                        shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();
-                        shader.uniforms['iTimeDelta'].value = clock.getDelta();
-                        shader.uniforms['iFrame'].value = 0;
-                        shader.uniforms['iMouse'].value = mouse;
-                        renderer.render(scene, camera);
-                    }
-                </script>
-            </body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/84/three.min.js"></script>              
+    <canvas id="canvas"></canvas>
+    <script id="vs" type="x-shader/x-vertex">
+        void main() {
+            gl_Position = vec4(position, 1.0);
+        }
+    </script>
+    <script id="fs" type="x-shader/x-fragment">
+        uniform vec3        iResolution;
+        uniform float       iGlobalTime;
+        uniform float       iTimeDelta;
+        uniform int         iFrame;
+        uniform float       iChannelTime[4];
+        uniform vec3        iChannelResolution[4];
+        uniform vec4        iMouse;
+        uniform sampler2D   iChannel0;
+        uniform sampler2D   iChannel1;
+        uniform sampler2D   iChannel2;
+        uniform sampler2D   iChannel3;                  
+                                
+        void main() {
+            gl_FragColor = vec4(1., 0., 0., 1.0);
+        }
+    </script>
+    <script type="text/javascript">
+        (function(){
+            console.error = function (message) {
+                if('7' in arguments) {
+                    $("#error").html("<h3>Shader failed to compile</h3><ul>")                                    
+                    $("#error").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
+                    $("#error").append("</ul>");
+                }
+            };
+        })();
+        var canvas = document.getElementById('canvas');
+        var scene = new THREE.Scene();
+        var renderer = new THREE.WebGLRenderer({canvas: canvas, antialias: true});
+        var camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientWidth, 1, 1000);
+        var clock = new THREE.Clock();
+        var resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
+        var channelResolution = new THREE.Vector3(128.0, 128.0, 0.0);
+        var mouse = new THREE.Vector4(0, 0, 0, 0);
+        var shader = new THREE.ShaderMaterial({
+                vertexShader: document.getElementById('vs').textContent,
+                fragmentShader: document.getElementById('fs').textContent,
+                depthWrite: false,
+                depthTest: false,
+                uniforms: {
+                    iResolution: { type: "v3", value: resolution },
+                    iGlobalTime: { type: "f", value: 0.0 },
+                    iTimeDelta: { type: "f", value: 0.0 },
+                    iFrame: { type: "i", value: 0 },
+                    iChannelTime: { type: "fv1", value: [0., 0., 0., 0.] }, 
+                    iChannelResolution: { type: "v3v", value:
+                        [channelResolution, channelResolution, channelResolution, channelResolution]   
+                    },
+                    iMouse: { type: "v4", value: mouse },
+                }
+            });
+        if(true) {
+            shader.uniforms.iChannel0 = { type: 't', value: THREE.ImageUtils.loadTexture("https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg") };
+            Function.prototype;
+            Function.prototype;
+            Function.prototype;
+        }
+        var quad = new THREE.Mesh(
+            new THREE.PlaneGeometry(2, 2),
+            shader
+        );
+        scene.add(quad);
+        camera.position.z = 10;
+        render();
+        function render() {
+            requestAnimationFrame(render);
+            if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
+                renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+                camera.aspect = canvas.clientWidth /  canvas.clientHeight;
+                camera.updateProjectionMatrix();
+                resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
+            }
+            
+            shader.uniforms['iResolution'].value = resolution;
+            shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();
+            shader.uniforms['iTimeDelta'].value = clock.getDelta();
+            shader.uniforms['iFrame'].value = 0;
+            shader.uniforms['iMouse'].value = mouse;
+            renderer.render(scene, camera);
+        }
+        canvas.addEventListener('mousemove', function(evt) {
+            if (mouse.z + mouse.w != 0) {
+                var rect = canvas.getBoundingClientRect();
+                mouse.x = evt.clientX - rect.left;
+                mouse.y = resolution.y - evt.clientY - rect.top;
+            } 
+        }, false);
+        canvas.addEventListener('mousedown', function(evt) {
+            if (evt.button == 0)
+                mouse.z = 1;
+            if (evt.button == 2)
+                mouse.w = 1;
+        }, false);
+        canvas.addEventListener('mouseup', function(evt) {
+            if (evt.button == 0)
+                mouse.z = 0;
+            if (evt.button == 2)
+                mouse.w = 0;
+        }, false);
+    </script>
+</body>

--- a/src/preview.html
+++ b/src/preview.html
@@ -42,7 +42,7 @@
                         console.error = function (message) {
                             if('7' in arguments) {
                                 $("#error").html("<h3>Shader failed to compile</h3><ul>")                                    
-                                $("#error").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 27); }));
+                                $("#error").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
                                 $("#error").append("</ul>");
                             }
                         };

--- a/src/preview.html
+++ b/src/preview.html
@@ -1,11 +1,10 @@
 <head>
     <style>
         html, body, #canvas { margin: 0; padding: 0; width: 100%; height: 100%; display: block; }
-        #error {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold;}
+        #message {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold;}
     </style>
 </head>
 <body>
-    <div id="error"></div>
     <div id="container"></div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
@@ -43,9 +42,10 @@
         (function(){
             console.error = function (message) {
                 if('7' in arguments) {
-                    $("#error").html("<h3>Shader failed to compile</h3><ul>")                                    
-                    $("#error").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
-                    $("#error").append("</ul>");
+                    $("#message").html("<h3>Shader failed to compile</h3><ul>")                                    
+                    $("#message").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
+                    $("#message").append("</ul>");
+                    shaderCompiled = false;
                 }
             };
         })();
@@ -57,6 +57,7 @@
         var resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
         var channelResolution = new THREE.Vector3(128.0, 128.0, 0.0);
         var mouse = new THREE.Vector4(0, 0, 0, 0);
+        var frameTime = 0.0;
         var shader = new THREE.ShaderMaterial({
                 vertexShader: document.getElementById('vs').textContent,
                 fragmentShader: document.getElementById('fs').textContent,
@@ -74,6 +75,7 @@
                     iMouse: { type: "v4", value: mouse },
                 }
             });
+        var shaderCompiled = true;
         if(true) {
             shader.uniforms.iChannel0 = { type: 't', value: THREE.ImageUtils.loadTexture("https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg") };
             Function.prototype;
@@ -102,6 +104,11 @@
             shader.uniforms['iFrame'].value = 0;
             shader.uniforms['iMouse'].value = mouse;
             renderer.render(scene, camera);
+            
+            if (shaderCompiled) {
+                frameTime = frameTime * 0.99 + clock.getDelta() * 0.01;
+                $("#message").html("FrameTime " + frameTime * 1000.0 + "ms");
+            }
         }
         canvas.addEventListener('mousemove', function(evt) {
             if (mouse.z + mouse.w != 0) {

--- a/src/preview.html
+++ b/src/preview.html
@@ -1,14 +1,15 @@
 <head>
     <style>
         html, body, #canvas { margin: 0; padding: 0; width: 100%; height: 100%; display: block; }
-        #message {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold;}
+        #message {font-family: Consolas; font-size: 1.2em; color:#ccc; background-color:black; font-weight: bold; z-index: 2; position: absolute;}
     </style>
 </head>
 <body>
+    <div id="message"></div>
     <div id="container"></div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/84/three.min.js"></script>              
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/84/three.min.js"></script>
     <canvas id="canvas"></canvas>
     <script id="vs" type="x-shader/x-vertex">
         void main() {
@@ -39,16 +40,31 @@
         }
     </script>
     <script type="text/javascript">
+        (function() {
+            var script = document.createElement('script')
+            script.onload = function() {
+                var stats = new Stats();
+			    stats.showPanel(1);
+                document.body.appendChild(stats.dom);
+                requestAnimationFrame(function loop() {
+                    stats.update();
+                    requestAnimationFrame(loop);
+                });
+            };
+            script.src = 'https://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';
+            document.head.appendChild(script);
+        }());
+    
         (function(){
             console.error = function (message) {
                 if('7' in arguments) {
                     $("#message").html("<h3>Shader failed to compile</h3><ul>")                                    
-                    $("#message").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 113); }));
+                    $("#message").append(arguments[7].replace(/ERROR: \d+:(\d+)/g, function(m, c) { return  "<li>Line " + String(Number(c) - 117); }));
                     $("#message").append("</ul>");
-                    shaderCompiled = false;
                 }
             };
         })();
+
         var canvas = document.getElementById('canvas');
         var scene = new THREE.Scene();
         var renderer = new THREE.WebGLRenderer({canvas: canvas, antialias: true});
@@ -57,7 +73,7 @@
         var resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
         var channelResolution = new THREE.Vector3(128.0, 128.0, 0.0);
         var mouse = new THREE.Vector4(0, 0, 0, 0);
-        var frameTime = 0.0;
+        var frameCounter = 0;
         var shader = new THREE.ShaderMaterial({
                 vertexShader: document.getElementById('vs').textContent,
                 fragmentShader: document.getElementById('fs').textContent,
@@ -75,13 +91,6 @@
                     iMouse: { type: "v4", value: mouse },
                 }
             });
-        var shaderCompiled = true;
-        if(true) {
-            shader.uniforms.iChannel0 = { type: 't', value: THREE.ImageUtils.loadTexture("https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg") };
-            Function.prototype;
-            Function.prototype;
-            Function.prototype;
-        }
         var quad = new THREE.Mesh(
             new THREE.PlaneGeometry(2, 2),
             shader
@@ -98,17 +107,15 @@
                 resolution = new THREE.Vector3(canvas.clientWidth, canvas.clientHeight, 1.0);
             }
             
-            shader.uniforms['iResolution'].value = resolution;
-            shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();
-            shader.uniforms['iTimeDelta'].value = clock.getDelta();
-            shader.uniforms['iFrame'].value = 0;
-            shader.uniforms['iMouse'].value = mouse;
-            renderer.render(scene, camera);
+            frameCounter++;
             
-            if (shaderCompiled) {
-                frameTime = frameTime * 0.99 + clock.getDelta() * 0.01;
-                $("#message").html("FrameTime " + frameTime * 1000.0 + "ms");
-            }
+            shader.uniforms['iResolution'].value = resolution;
+            shader.uniforms['iTimeDelta'].value = clock.getDelta();
+            shader.uniforms['iGlobalTime'].value = clock.getElapsedTime();
+            shader.uniforms['iFrame'].value = frameCounter;
+            shader.uniforms['iMouse'].value = mouse;
+            
+            renderer.render(scene, camera);
         }
         canvas.addEventListener('mousemove', function(evt) {
             if (mouse.z + mouse.w != 0) {

--- a/src/preview.html
+++ b/src/preview.html
@@ -27,7 +27,13 @@
         uniform sampler2D   iChannel0;
         uniform sampler2D   iChannel1;
         uniform sampler2D   iChannel2;
-        uniform sampler2D   iChannel3;                  
+        uniform sampler2D   iChannel3;
+        uniform sampler2D   iChannel4;
+        uniform sampler2D   iChannel5;
+        uniform sampler2D   iChannel6;
+        uniform sampler2D   iChannel7;
+        uniform sampler2D   iChannel8;
+        uniform sampler2D   iChannel9;              
                                 
         void main() {
             gl_FragColor = vec4(1., 0., 0., 1.0);


### PR DESCRIPTION
Disclaimer: I have no experience with ts, js or html. So the code I wrote might very well not be according to common standards.

Over the weekend and the past days I added some features that make my life easier when using the shader-toy expansion in my daily work.

- Added a preprocessor definition SHADER_TOY to help with shaders that are used in multiple places, i.e. debugged in shader-toy and used in an engine at the same time.
- Bumped up the number of available channels from 4 to 10
- Added an option _reloadOnChangeEditor_ which causes shader-toy to recompile when changing the active editor in Visual Studio Code. Default value is false.
- Added an option _useInShaderTextures_ which allows to use preprocessor-like definitions of textures directly in the shader, a demo _blending.glsl_ was added which showcases the feature. This feature replaces the textures defined in settings. Default value is false.
- Added an option _printShaderFrameTime_ which makes use of _stats.js_ to print the time it takes to render a frame. Default value is false.
- Fixed up _line_offset_ to show the correct line number in compilation errors. This still breaks every time the preamble of the generated shader is changed and has to be maintained by hand.
- Added support for iFrame, which is simply a frame-counter.
- Added support for iMouse, working in precisely the same way as advertised on *shadertoy.com*. Modified the demo _metaballs.glsl_ to use iMouse again.

I hope the contributions make it into master to be published. But please examine the code carefully to make sure I broke nothing.