### PR TITLE
Loading non-existent buffer fails completely on some PCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
                     "type": "object",
                     "default": {
                         "0": "https://www.example.my/cool.png",
-                        "1": "file://./relative.jpg",
-                        "2": "buf://./other-shader.glsl"
+                        "1": "file://./relative.jpg"
                     },
                     "description": "The texture channels (iChannel0, iChannel1, ...) using http:// or file:// protocol or buf:// to reference another shader. To use relative paths open a workspace."
                 }


### PR DESCRIPTION
This was my f*-up with trying to present some default values as examples for loading buffers