### PR TITLE
Added ability to include a common glsl file

### DIFF
--- a/demos/blobby.glsl
+++ b/demos/blobby.glsl
@@ -1,4 +1,4 @@
-#iCommon glsl://./common/blobby-common.glsl
+#include glsl://./common/blobby-common.glsl
 
 float blob(vec2 pos, vec2 center, float power)
 {

--- a/demos/blobby.glsl
+++ b/demos/blobby.glsl
@@ -1,0 +1,44 @@
+#iCommon glsl://./common/blobby-common.glsl
+
+float blob(vec2 pos, vec2 center, float power)
+{
+    vec2 d = saturate01(pow(pos - center, vec2(power)));
+    return 1. / abs(d.x + d.y);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 uv = fragCoord / iResolution.xy;
+    uv = (uv - .5) * 2.0; 
+    vec2 aspect_uv = uv * (iResolution.xy / iResolution.y);
+        
+    float blobs = 0.8 * blob(aspect_uv, vec2(0.), 2.);
+    
+    float phi = 0.;
+    
+    const int N = 7;
+    
+    for (int i = 0; i < N; ++i)
+    {
+        blobs += 0.0001 * blob(rotate(aspect_uv, phi), 
+                               vec2(sin(iTime + phi) * 0.64, 0.),
+                               4.);
+        
+        blobs += 0.001 * blob(rotate(aspect_uv, phi), 
+                              vec2(-sin(iTime + phi + 5. * PI / 6.) * 0.50, 0.),
+                              2.);
+        phi += PI / float(N);
+    }
+    
+    float x = smoothstep(3., 6., blobs);
+    float y = smoothstep(3., 5., blobs);
+    float z = smoothstep(3., 8., blobs);
+    
+    fragColor = vec4(20.1, 2., 2.1, 5.) - vec4(x * vec3(1., 0.5, 0.5) + 
+                                              y * vec3(2.5, 1., 0.5) + 
+                                              z * vec3(.5, 0.5, 1.), 1.);
+    
+    
+    fragColor = vec4((1. - vec3(pow(length(uv * 0.4), 1.5))) * vec3(0.9, 1.0, 0.9),
+                     1.) * saturate01(pow(fragColor, vec4(2.7)));
+}

--- a/demos/common/blobby-common.glsl
+++ b/demos/common/blobby-common.glsl
@@ -1,0 +1,8 @@
+const float PI = 3.14159;
+
+#define saturate01(x) (clamp(x, 0., 1.))
+
+vec2 rotate(vec2 p, float t)
+{
+    return mat2(cos(t), -sin(t), sin(t), cos(t)) * p;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -688,24 +688,33 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 }
             }
             else if (textureType == "glsl") {
-                // Read the whole file of the shader
-                const shaderFile = this.readShaderFile(file);
-                if(shaderFile.success == false){
-                    vscode.window.showErrorMessage(`Could not open file: ${origFile}`);
-                    return;
-                }
                 const path = require("path");
-                commonName = path.basename(file);
-                commonIncludes.push(
-                    {
-                        Name: commonName,
-                        File: file,
-                        Code: shaderFile.bufferCode
+                const name = path.basename(file);
+
+                // Check if the include already exists
+                const appendInclude = commonIncludes.findIndex(include => include.File === file) === -1;
+                if (appendInclude) {
+                    // Read the whole file of the shader
+                    const shaderFile = this.readShaderFile(file);
+                    if(shaderFile.success == false){
+                        vscode.window.showErrorMessage(`Could not open file: ${origFile}`);
+                        return;
                     }
-                );
-                
-                const lineCount = shaderFile.bufferCode.split(/\r\n|\n/).length;
-                line_offset += lineCount;
+
+                    commonIncludes.push(
+                        {
+                            Name: name,
+                            File: file,
+                            Code: shaderFile.bufferCode
+                        }
+                    );
+
+                    const lineCount = shaderFile.bufferCode.split(/\r\n|\n/).length;
+                    line_offset += lineCount;
+                }
+
+                // reference this include
+                commonName = name;
             }
             else if (textureType == "file") {
                 // Push texture


### PR DESCRIPTION
I've managed to emulate the shadertoy common pass. 

I've setup a new definition called "#iCommon". I didnt want to affect any existing protocols so I've added a new protocol called "glsl://". Full example:  `#iCommon glsl://./common/blobby-common.glsl`
Let me know what your happy with for define and protocol naming covention.

I've added a demo called blobby. I've mutated it from https://www.shadertoy.com/view/ldBBRV. (I will remove the demo if you dont want it there)

The only thing I haven't done is compile the common file on its own. The workaround is to manually add a "void main() {}" temporarily when working in the common file.



