### PR TITLE
Fixed mouse position when mouse down but not moving

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -513,24 +513,35 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         }
                     }
                 }
+                let dragging = false;
+                function updateMouse(clientX, clientY) {
+                    var rect = canvas.getBoundingClientRect();
+                    mouse.x = clientX - rect.left;
+                    mouse.y = resolution.y - clientY - rect.top;
+                }
                 canvas.addEventListener('mousemove', function(evt) {
                     if (mouse.z + mouse.w != 0) {
-                        var rect = canvas.getBoundingClientRect();
-                        mouse.x = evt.clientX - rect.left;
-                        mouse.y = resolution.y - evt.clientY - rect.top;
-                    } 
+                        updateMouse(evt.clientX, evt.clientY);
+                     } 
                 }, false);
                 canvas.addEventListener('mousedown', function(evt) {
                     if (evt.button == 0)
                         mouse.z = 1;
                     if (evt.button == 2)
                         mouse.w = 1;
+
+                    if (!dragging) {
+                        updateMouse(evt.clientX, evt.clientY);
+                        dragging = true
+                    }
                 }, false);
                 canvas.addEventListener('mouseup', function(evt) {
                     if (evt.button == 0)
                         mouse.z = 0;
                     if (evt.button == 2)
                         mouse.w = 0;
+
+                    dragging = false;
                 }, false);
             </script>
         `;


### PR DESCRIPTION
Single mouse clicking is acting strange and doesn't update iMouse when there is no movement from the mouse.
 
This fix recreates the same behaviour as shadertoy

Test code

```glsl
float sdPoint(vec2 point, vec2 uv, float radius, float blur) {
    float point_dist = 0.;
    point_dist = length(point - uv);
    point_dist = smoothstep(radius,radius + blur, point_dist);
    return point_dist;
}

void mainImage(out vec4 fragColor, in vec2 fragCoord)
{
    vec2 uv = fragCoord / iResolution.xy;
    vec2 umv = iMouse.xy / iResolution.xy;
    uv -= .5;
    umv -= .5;

    uv.x *= iResolution.x / iResolution.y;
    umv.x *= iResolution.x / iResolution.y;

    vec3 col = vec3(0);
    vec2 point = vec2(0.);

    // calc the dist
    float point_dist = sdPoint(point, uv, .01, 0.005);
    col += vec3(1. - point_dist) * vec3(1., 0, 0);

    bool hasMouseClick = (iMouse.z > 0. || iMouse.w > 0.);
    
    // if(hasMouseClick) // uncomment for dragging only when mouse down
    {
        // calc mouse dist
        float mouse_dist = sdPoint(umv, uv, .01, 0.005);
        col += vec3(1. - mouse_dist) * vec3(1., 1, 0);
    }

    // Output to screen
    fragColor = vec4(col, 1.0);
}
```