### PR TITLE
Keyboard input

### DIFF
--- a/demos/keyboard.glsl
+++ b/demos/keyboard.glsl
@@ -1,7 +1,0 @@
-#iKeyboard
-
-void main() {
-    vec2 uv = gl_FragCoord.xy / iResolution.xy;
-
-    gl_FragColor = vec4(texture(iKeyboard, uv).r, 0.0, 0.0, 1.0);   
-}

--- a/demos/keyboard.glsl
+++ b/demos/keyboard.glsl
@@ -1,0 +1,7 @@
+#iKeyboard
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / iResolution.xy;
+
+    gl_FragColor = vec4(texture(iKeyboard, uv).r, 0.0, 0.0, 1.0);   
+}

--- a/demos/keyboard.glsl
+++ b/demos/keyboard.glsl
@@ -1,0 +1,114 @@
+#iKeyboard
+
+// Created by inigo quilez - iq/2013
+// Adapted for VS Code Shadertoy
+
+// An example showing how to use the keyboard input.
+//
+// Row 0: contain the current state of the 256 keys. 
+// Row 1: contains Keypress.
+// Row 2: contains a toggle for every key.
+// Row 3: contains Keyrelease.
+//
+// Texel positions correspond to ASCII codes. Press arrow keys to test.
+
+// #define USE_TEXEL_FETCH
+
+const int KEY_LEFT  = Key_LeftArrow;
+const int KEY_UP    = Key_UpArrow;
+const int KEY_RIGHT = Key_RightArrow;
+const int KEY_DOWN  = Key_DownArrow;
+
+#ifdef USE_TEXEL_FETCH
+float state(int key) {
+    return texelFetch(iKeyboard, ivec2(key, 0), 0).x;
+}
+float keypress(int key) {
+    return texelFetch(iKeyboard, ivec2(key, 1), 0).x;
+}
+float keyrelease(int key) {
+    return texelFetch(iKeyboard, ivec2(key, 3), 0).x;
+}
+float toggle(int key) {
+    return texelFetch(iKeyboard, ivec2(key, 2), 0).x;
+}
+#else
+float state(int key) {
+    return isKeyDown(key) ? 1.0 : 0.0;
+}
+float keypress(int key) {
+    return isKeyPressed(key) ? 1.0 : 0.0;
+}
+float keyrelease(int key) {
+    return isKeyReleased(key) ? 1.0 : 0.0;
+}
+float toggle(int key) {
+    return isKeyToggled(key) ? 1.0 : 0.0;
+}
+#endif
+
+void stateColor(inout vec3 col, const in vec2 uv,
+                const in vec3 keyCol, const in vec2 keyPos, const in int key) {
+    col = mix(col, keyCol,
+        (1.0 - smoothstep(0.3, 0.31, length(uv - keyPos))) * 
+        (0.3 + 0.7 * state(key)));
+}
+void keypressColor(inout vec3 col, const in vec2 uv,
+                   const in vec3 keyCol, const in vec2 keyPos, const in int key) {
+    col = mix(col, keyCol,
+        (1.0 - smoothstep(0.0, 0.01, abs(length(uv - keyPos) - 0.35))) *
+        keypress(key));
+}
+void keyreleaseColor(inout vec3 col, const in vec2 uv,
+                   const in vec3 keyCol, const in vec2 keyPos, const in int key) {
+    col = mix(col, keyCol,
+        (1.0 - smoothstep(0.0, 0.01, abs(length(uv - keyPos) - 0.4))) *
+        keyrelease(key));
+}
+void toggleColor(inout vec3 col, const in vec2 uv,
+                   const in vec3 keyCol, const in vec2 keyPos, const in int key) {
+    col = mix(col, keyCol,
+        (1.0 - smoothstep(0.0, 0.01, abs(length(uv - keyPos) - 0.3))) *
+        toggle(key));
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    const vec3 red = vec3(1.0,0.0,0.0);
+    const vec3 yellow = vec3(1.0,1.0,0.0);
+    const vec3 green = vec3(0.0,1.0,0.0);
+    const vec3 blue = vec3(0.0,0.0,1.0);
+
+    const vec2 redPos = vec2(-0.75,0.0);
+    const vec2 yellowPos = vec2(0.0,0.5);
+    const vec2 greenPos = vec2(0.75,0.0);
+    const vec2 bluePos = vec2(0.0,-0.5);
+
+    vec2 uv = (-iResolution.xy + 2.0*fragCoord) * 2.0 / iResolution.y;
+    vec3 col = vec3(0.0);
+
+    // state
+    stateColor(col, uv, red, redPos, KEY_LEFT);
+    stateColor(col, uv, yellow, yellowPos, KEY_UP);
+    stateColor(col, uv, green, greenPos, KEY_RIGHT);
+    stateColor(col, uv, blue, bluePos, KEY_DOWN);
+
+    // keypress
+    keypressColor(col, uv, red, redPos, KEY_LEFT);
+    keypressColor(col, uv, yellow, yellowPos, KEY_UP);
+    keypressColor(col, uv, green, greenPos, KEY_RIGHT);
+    keypressColor(col, uv, blue, bluePos, KEY_DOWN);
+
+    // keyrelease
+    keyreleaseColor(col, uv, red, redPos, KEY_LEFT);
+    keyreleaseColor(col, uv, yellow, yellowPos, KEY_UP);
+    keyreleaseColor(col, uv, green, greenPos, KEY_RIGHT);
+    keyreleaseColor(col, uv, blue, bluePos, KEY_DOWN);
+    
+    // toggle
+    toggleColor(col, uv, red, redPos, KEY_LEFT);
+    toggleColor(col, uv, yellow, yellowPos, KEY_UP);
+    toggleColor(col, uv, green, greenPos, KEY_RIGHT);
+    toggleColor(col, uv, blue, bluePos, KEY_DOWN);
+
+    fragColor = vec4(col,1.0);
+}

--- a/demos/keyquest.glsl
+++ b/demos/keyquest.glsl
@@ -1,0 +1,698 @@
+#iKeyboard
+#iChannel0 http://i.imgur.com/lX8OAQV.jpg
+#iChannel1 http://farm5.static.flickr.com/4541/38604095012_ab7a81b807_b.jpg
+
+// Ben Quantock 2014
+// License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+// Adapted for shadertoy VS-Code from: https://www.shadertoy.com/view/XdS3RV
+
+// fit a coordinate system to xx
+vec4 screen; // coord*screen.z+screen.xy, coord e [-screen.w,screen.w
+vec2 pixel;
+vec2 fragCoord;
+vec4 fragColor;
+
+void Fit( float w )
+{
+	screen.w = w;
+	screen.xy = iResolution.xy/2.0;
+	screen.z = min(screen.x,screen.y)/screen.w;
+	
+	pixel = (fragCoord.xy-screen.xy)/screen.z;
+}
+
+bool ReadKey( int key )//, bool toggle )
+{
+	return isKeyToggled(key);
+}
+
+
+
+// Character definitions.
+vec2	A[6],B[6],C[6],D[6],E[6],F[6],G[6],H[6],I[6],J[6],
+		K[6],L[6],M[6],N[6],O[6],P[6],Q[6],R[6],S[6],T[6],
+		U[6],V[6],W[6],X[6],Y[6],Z[6],c0[6],c1[6],c2[6],c3[6],
+		c4[6],c5[6],c6[6],c7[6],c8[6],c9[6],c_[6];
+
+void DefC( inout vec2 c[6], vec2 A, vec2 B, vec2 C, vec2 D, vec2 E, vec2 F )
+{
+	c[0] = A; c[1] = B; c[2]=C; c[3]=D; c[4]=E; c[5]=F;
+}
+
+// WHY CAN'T I INITIALIZE A CONST ARRAY????!!!! The compiler would be able to hard code all the values!!! STUPID COMPILER! *headdesk*
+void DefineChars()
+{
+	DefC( A, vec2(-1,0), vec2(3,8), vec2(7,0), vec2(6,2), vec2(0,2), vec2(1,2) );
+	DefC( B, vec2(0,0), vec2(0,8), vec2(6,6), vec2(3,4), vec2(7,0), vec2(0,0) );
+	DefC( C, vec2(6,8), vec2(3,8), vec2(0,5), vec2(0,3), vec2(3,0), vec2(6,0) );
+	DefC( D, vec2(0,0), vec2(0,8), vec2(3,8), vec2(6,5), vec2(6,0), vec2(0,0) );
+	DefC( E, vec2(6,0), vec2(0,0), vec2(0,4), vec2(4,4), vec2(0,8), vec2(6,8) );
+	DefC( F, vec2(0,0), vec2(0,4), vec2(4,4), vec2(0,4), vec2(0,8), vec2(6,8) );
+	DefC( G, vec2(6,8), vec2(3,8), vec2(0,4), vec2(3,0), vec2(6,0), vec2(6,4) );
+	DefC( H, vec2(0,0), vec2(0,8), vec2(0,4), vec2(6,4), vec2(6,0), vec2(6,8) );
+	DefC( I, vec2(0,0), vec2(6,0), vec2(3,0), vec2(3,8), vec2(0,8), vec2(6,8) );
+	DefC( J, vec2(0,0), vec2(2,0), vec2(3,1), vec2(3,8), vec2(0,8), vec2(6,8) );
+	DefC( K, vec2(5,8), vec2(1,4), vec2(1,8), vec2(1,0), vec2(1,4), vec2(5,0) );
+	DefC( L, vec2(6,0), vec2(0,0), vec2(0,8), vec2(0,8), vec2(0,8), vec2(0,8) );
+	DefC( M, vec2(-1,0), vec2(-1,8), vec2(3,5), vec2(7,8), vec2(7,0), vec2(7,0) );
+	DefC( N, vec2(0,0), vec2(0,8), vec2(6,0), vec2(6,8), vec2(6,8), vec2(6,8) );
+	DefC( O, vec2(3,8), vec2(6,6), vec2(6,2), vec2(3,0), vec2(0,2), vec2(0,6) );
+	DefC( P, vec2(0,0), vec2(0,8), vec2(4,8), vec2(6,6), vec2(6,3), vec2(0,3) );
+	DefC( Q, vec2(3,0), vec2(0,4), vec2(3,8), vec2(6,4), vec2(4,3), vec2(6,0) );
+	DefC( R, vec2(0,0), vec2(0,8), vec2(3,8), vec2(6,5), vec2(3,3), vec2(6,0) );
+	DefC( S, vec2(5,8), vec2(0,8), vec2(0,4), vec2(6,4), vec2(6,0), vec2(0,0) );
+	DefC( T, vec2(0,8), vec2(6,8), vec2(3,8), vec2(3,0), vec2(3,0), vec2(3,0) );
+	DefC( U, vec2(0,8), vec2(0,2), vec2(2,0), vec2(6,0), vec2(6,8), vec2(6,8) );
+	DefC( V, vec2(0,8), vec2(3,0), vec2(6,8), vec2(6,8), vec2(6,8), vec2(6,8) );
+	DefC( W, vec2(-1,8), vec2(0,0), vec2(3,4), vec2(6,0), vec2(7,8), vec2(7,8) );
+	DefC( X, vec2(0,0), vec2(6,8), vec2(3,4), vec2(0,8), vec2(6,0), vec2(6,0) );
+	DefC( Y, vec2(0,0), vec2(6,8), vec2(3,4), vec2(0,8), vec2(0,8), vec2(0,8) );
+	DefC( Z, vec2(0,8), vec2(6,8), vec2(0,0), vec2(6,0), vec2(6,0), vec2(6,0) );
+
+	DefC( c0, vec2(0,1), vec2(6,7), vec2(6,0), vec2(0,0), vec2(0,8), vec2(6,8) );
+	DefC( c1, vec2(1,6), vec2(3,8), vec2(3,0), vec2(0,0), vec2(6,0), vec2(6,0) );
+	DefC( c2, vec2(1,7), vec2(3,8), vec2(6,6), vec2(6,4), vec2(0,0), vec2(6,0) );
+	DefC( c3, vec2(0,8), vec2(6,8), vec2(4,5), vec2(6,3), vec2(6,0), vec2(0,0) );
+	DefC( c4, vec2(4,0), vec2(4,8), vec2(0,4), vec2(0,3), vec2(6,3), vec2(0,3) );
+	DefC( c5, vec2(0,0), vec2(3,0), vec2(6,5), vec2(0,5), vec2(0,8), vec2(6,8) );
+	DefC( c6, vec2(6,8), vec2(0,5), vec2(0,0), vec2(6,0), vec2(6,5), vec2(0,5) );
+	DefC( c7, vec2(0,8), vec2(6,8), vec2(0,0), vec2(0,0), vec2(0,0), vec2(0,0) );
+	DefC( c8, vec2(6,0), vec2(0,0), vec2(6,8), vec2(0,8), vec2(0,8), vec2(6,0) );
+	DefC( c9, vec2(0,0), vec2(6,3), vec2(6,8), vec2(0,8), vec2(0,5), vec2(4,5) );
+
+	// space - put points off screen
+	DefC( c_, vec2(0,-10000), vec2(0,-10000), vec2(0,-10000), vec2(0,-10000), vec2(0,-10000), vec2(0,-10000) );
+}
+
+vec3 s_textCol = vec3(1);
+float s_textScale = 1.0;
+
+// col = current pixel colour (will be modified if pixel hits letter)
+void DrawChar( vec2 pos, vec2 lines[6] )//vec2 A, vec2 B, vec2 C, vec2 D, vec2 E, vec2 F )
+{
+	//vec2 lines[6]; lines[0] = A; lines[1] = B; lines[2]=C; lines[3]=D; lines[4]=E; lines[5]=F;
+	vec2 p = pixel-pos-.5;
+	
+	p /= s_textScale;
+	p += vec2(3,4); // offset to centre of characters
+
+	float c = 100.0;
+	
+	for ( int l=0; l < 5; l++ )
+	{
+		// find distance from line
+		vec2 pp = p - lines[l];
+		
+		float d = dot( pp, normalize(lines[l+1]-lines[l]) );
+		float e =  dot(pp,pp) - d*d;
+		
+		// make a distance field for the letter
+		//c = min( c, max( e, max( -.5-d, d-.5-length(lines[l+1]-lines[l]) ) ) );
+		if ( d > -.5/s_textScale && d < .5/s_textScale+length(lines[l+1]-lines[l]) )
+		{
+			c = min( c, sqrt(e) );
+		}
+		else
+		{
+			c = min ( c, min( length(pp), length( p - lines[l+1] ) ) );
+		}
+		
+/*		if ( d > -.5 && d < .5+length(lines[l+1]-lines[l])
+		   	&& e < 1.0 )
+		{
+			col = vec3(0);
+			return;
+		}*/
+	}
+	
+	// outline
+	fragColor.rgb = mix ( vec3(0), fragColor.rgb, smoothstep( 0.6, 2.0, c ) );
+	
+	// fill
+	fragColor.rgb = mix ( s_textCol, fragColor.rgb, smoothstep( 0.0, 1.0/min(s_textScale,1.0), c ) );
+}
+
+
+vec2 s_cursor;
+float s_margin;
+
+void PrintPos( vec2 pos )
+{
+	s_cursor = pos;
+	s_margin = pos.x;
+}
+
+void Print( vec2 ch[6] )
+{
+	DrawChar( s_cursor, ch );
+	s_cursor.x += s_textScale*10.0;
+}
+
+void Print( vec2 a[6], vec2 b[6], vec2 c[6], vec2 d[6], vec2 e[6], vec2 f[6], vec2 g[6], vec2 h[6], vec2 i[6] )
+{
+	Print(a);
+	Print(b);
+	Print(c);
+	Print(d);
+	Print(e);
+	Print(f);
+	Print(g);
+	Print(h);
+	Print(i);
+}
+
+void NewLine()
+{
+	s_cursor.x = s_margin;
+	s_cursor.y -= s_textScale*14.0;
+}
+
+
+
+// sprites
+void DrawDirt()
+{
+	if ( abs(pixel.x) < 180.0 && abs(pixel.y) < 180.0 )
+	{
+		fragColor.rgb = mix( vec3(.2,.1,.05), vec3(.35,.2,.13), texture( iChannel0, pixel/40.0 ).r);
+	}
+}
+
+void DrawTrees( vec2 pos )
+{
+	vec2 p = pixel-pos;
+	vec2 ap = abs(p);
+	vec4 t = texture( iChannel0, pixel*vec2(2,1)/80.0 );
+	if ( max(ap.x,ap.y) < 60.0+10.0*pow(t.b,.5) )
+	{
+		fragColor.rgb = mix( vec3(.0,.0,.0), vec3(.0,.3,.0), t.g);
+	}
+}
+
+void DrawPaving()
+{
+	if ( abs(pixel.x) < 180.0 && abs(pixel.y) < 180.0 )
+	{
+//		fragColor.rgb = mix( vec3(.0), vec3(.2), pow(texture( iChannel0, pixel/120.0+.5 ).r,.5) );
+		fragColor.rgb = mix( vec3(.0), vec3(.3,.25,.2), pow(texture( iChannel1, pixel/60.0+.5 ).r,.5) );
+	}
+}
+
+void DrawWalls( vec2 pos )
+{
+	vec2 p = pixel-pos;
+	vec2 ap = abs(p);
+	vec4 t = texture( iChannel0, pixel*vec2(1,1)/60.0 );
+	if ( max(ap.x,ap.y-20.0) < 60.0+4.0*pow((1.0-t.g),2.0) )
+	{
+		fragColor.rgb = mix( vec3(.4,.5,.6)*.2, vec3(.4,.5,.6), pow(1.0-t.r,5.0));
+		
+		fragColor.rgb *= mix( .3, 1.5, smoothstep( -40.0, -35.0, p.y ) );
+	}
+}
+
+vec3 Key1Col()
+{
+	return mix ( vec3(.4,.6,.9), vec3(1), smoothstep( 0.7, 1.0, sin((pixel.x+pixel.y)*.1-6.0*iTime) ) );
+}
+
+vec3 Key2Col()
+{
+	return mix ( vec3(1.0,.4,.0), vec3(1), smoothstep( 0.7, 1.0, sin((pixel.x+pixel.y)*.1-6.0*iTime) ) );
+}
+
+
+void DrawKey( vec2 pos, vec3 keyCol )
+{
+	vec2 p = pixel-pos;
+	vec2 c = p-vec2(5,0);
+	
+	bool draw = false;
+	if ( abs(p.x) < 10.0 && abs(p.y) < 5.0 )
+	{
+		if ( p.x > 1.0 )
+		{
+			if ( length(c) < 5.0 && length(c-vec2(1,0)) > 2.0 )
+				draw = true;
+		}
+		else
+		{
+			if ( p.y < 2.0 &&
+				p.y > 10.0-20.0*texture( iChannel1, vec2(0,pixel.x/5.0) ).r )
+				draw = true;
+		}
+	}
+	
+	if ( draw )
+		fragColor.rgb = keyCol;
+}
+
+void DrawDoor( vec2 pos, vec3 keyCol )
+{
+	vec2 p = pixel-pos;
+	vec2 ap = abs(p);
+	vec4 t = texture( iChannel1, pixel.yx/40.0 );
+	if ( max(ap.x,ap.y+20.0) < 60.0+4.0*pow((1.0-t.g),2.0) )
+	{
+		fragColor.rgb = mix( vec3(.2,.1,.03), vec3(0), t.r);
+		
+		fragColor.rgb *= 1.0+1.0*step(10.0,p.y); // lighting on top
+		
+		fragColor.rgb = mix( fragColor.rgb, vec3(0), step(-1.0,-ap.x) );
+		
+		// keyhole
+		vec2 lp = p-vec2(0,-15);
+		if ( abs(lp.x) < 6.0 && abs(lp.y) < 4.0 )
+		{
+			fragColor.rgb = keyCol;
+			
+			fragColor.rgb *= smoothstep(1.0,2.0, length(lp));
+		}
+	}
+}
+
+
+// compiler gets angry (on my office PC) if I draw chars all over the place
+// => draw all 7 letters once, but offset their position inside the conditions
+void North( out vec2 p ) { p = vec2(0, 170); }
+void South( out vec2 p ) { p = vec2(0,-170); }
+void East ( out vec2 p ) { p = vec2( 170,0); }
+void West ( out vec2 p ) { p = vec2(-170,0); }
+/*void North( out vec2 p ) { p = vec2(-170, 170); } // isometric
+void South( out vec2 p ) { p = vec2( 170,-170); }
+void East ( out vec2 p ) { p = vec2( 170, 170); }
+void West ( out vec2 p ) { p = vec2(-170,-170); }*/
+	
+
+void mainImage( out vec4 oFragColor, in vec2 iFragCoord )
+{
+	fragColor = vec4(.7);
+	fragCoord = iFragCoord;
+	// my base coord system
+	Fit(180.0);
+	
+	DefineChars();
+
+	s_textScale = 2.0;
+	s_textCol = mix( vec3(1,1,0), vec3(0,1,1),
+					step(.0,cos(4.0*6.28*iTime))
+					*step(.8,cos(.1*6.28*iTime))
+				);
+	
+	/*
+	MAP (spoilers!):
+	D D-E-F E
+	| |     |
+	C-B-A-C-D
+	===]|[===
+	E-D-#-B-C
+	|   | |
+	F D-C D-E
+	  |   | |
+	F-E G-F F
+	*/
+	
+	// Compiler can get angry if I draw stuff inside each "if"
+	// so, instead, move things inside the ifs and draw once afterwards
+	vec2 a=vec2(-999), b=vec2(-999), c=vec2(-999), d=vec2(-999), e=vec2(-999), f=vec2(-999), g=vec2(-999);
+	
+// how can I describe the environment in similar terms?
+//=> a few stock pieces which I position
+	bool trees[9];
+	bool walls[9];
+	bool paved = false; // false = dirt, true = stone
+	for ( int i = 0; i < 9; i++ )
+	{
+		trees[i] = false;
+		walls[i] = false;
+	}
+	bool drawDoor1 = false;
+	bool drawDoor2 = false;
+	bool drawKey1 = false;
+	bool drawKey2 = false;
+	
+	// could use date to randomise these, to prevent cheating, but that's a bit OTT.
+	bool gotKey1 = ReadKey(Key_K);
+	bool gotKey2 = ReadKey(Key_H);
+	
+	bool win = false;
+	
+	if ( ReadKey(Key_A) && gotKey1 )
+	{
+		// inside castle
+		paved = true;
+
+		walls[0] = walls[2] = walls[6] = walls[8] = true;
+
+		
+		if ( ReadKey(Key_B) )
+		{
+			if ( ReadKey(Key_C) )
+			{
+				if ( ReadKey(Key_D) )
+				{
+					South(d);
+
+					walls[1] = true;
+					walls[3] = true;
+					walls[5] = true;
+				}
+				else
+				{
+					North(d);
+					East(c);
+
+					walls[3] = true;
+					walls[7] = true;
+				}
+			}
+			else if ( ReadKey(Key_D) )
+			{
+				if ( ReadKey(Key_E) )
+				{
+					if ( ReadKey(Key_F) )
+					{
+						West( f );
+
+						walls[1] = true;
+						walls[5] = true;
+						walls[7] = true;
+						
+						if ( !gotKey2 )
+							drawKey2 = true;
+					}
+					else
+					{
+						East( f );
+						West( e );
+
+						walls[1] = true;
+						walls[7] = true;
+					}
+				}
+				else
+				{
+					East( e );
+					South( d );
+
+					walls[1] = true;
+					walls[3] = true;
+				}
+			}
+			else
+			{
+				East( b );
+				West( c );
+				North( d );
+
+				walls[7] = true;
+			}
+		}
+		else if ( ReadKey(Key_C) )
+		{
+			if ( ReadKey(Key_D) )
+			{
+				if ( ReadKey(Key_E) )
+				{
+					if ( ReadKey(Key_F) && gotKey2 )
+					{
+						win = true;
+					}
+					else
+					{
+						South( e );
+						
+						walls[3] = true;
+						walls[5] = true;
+						
+						drawDoor2 = true;
+	
+						if ( gotKey2 )
+						{
+							North( f );
+						}
+					}
+				}
+				else
+				{
+					North( e );
+					West( d );
+
+					walls[5] = true;
+					walls[7] = true;
+				}
+			}
+			else
+			{
+				East( d );
+				West( c );
+
+				walls[1] = true;
+				walls[7] = true;
+			}
+		}
+		else
+		{
+			East( c );
+			West( b );
+			South( a );
+			
+			walls[1] = true;
+		}
+	}
+	else if ( ReadKey(Key_B) )
+	{
+		if ( ReadKey(Key_C) )
+		{
+			West( c );
+
+			walls[0] = walls[1] = walls[2] = true;
+			trees[5] = trees[6] = trees[7] = trees[8] = true;
+		}
+		else if ( ReadKey(Key_D) )
+		{
+			trees[0] = trees[2] = trees[6] = trees[8] = true;
+
+			if ( ReadKey(Key_E) )
+			{
+				if ( ReadKey(Key_F) )
+				{
+					if ( !gotKey1 )
+						drawKey1 = true;
+
+					North( f );
+
+					trees[3] = true;
+					trees[5] = true;
+					trees[7] = true;
+				}
+				else
+				{
+					South( f );
+					West( e );
+
+					trees[1] = true;
+					trees[5] = true;
+				}
+			}
+			else if ( ReadKey(Key_F) )
+			{
+				if ( ReadKey(Key_G) )
+				{
+					East( g );
+
+					trees[1] = true;
+					trees[3] = true;
+					trees[7] = true;
+				}
+				else
+				{
+					West( g );
+					North( f );
+
+					trees[5] = true;
+					trees[7] = true;
+				}
+			}
+			else
+			{
+				South( f );
+				East( e );
+				North( d );
+
+				trees[3] = true;
+			}
+		}
+		else
+		{
+			South( d );
+			West( b );
+			East( c );
+
+			walls[0] = walls[1] = walls[2] = true;
+			trees[6] = trees[8] = true;
+		}
+	}
+	else if ( ReadKey(Key_C) )
+	{
+		trees[0] = trees[2] = trees[6] = trees[8] = true;
+
+		if ( ReadKey(Key_D) )
+		{
+			if ( ReadKey(Key_E) )
+			{
+				if ( ReadKey(Key_F) )
+				{
+					East( f );
+
+					trees[1] = true;
+					trees[3] = true;
+					trees[7] = true;
+				}
+				else
+				{
+					West( f );
+					North( e );
+
+					trees[5] = true;
+					trees[7] = true;
+				}
+			}
+			else
+			{
+				South( e );
+				East( d );
+
+				trees[1] = true;
+				trees[3] = true;
+			}
+		}
+		else
+		{
+			West( d );
+			North( c );
+
+			trees[5] = true;
+			trees[7] = true;
+		}
+	}
+	else if ( ReadKey(Key_D) )
+	{
+		walls[0] = walls[1] = walls[2] = true;
+		trees[6] = trees[8] = true;
+
+		if ( ReadKey(Key_E) )
+		{
+			if ( ReadKey(Key_F) )
+			{
+				North( f );
+
+				walls[0] = walls[1] = walls[2] = false;
+				trees[0] = trees[2] = true;
+				trees[3] = true;
+				trees[5] = true;
+				trees[7] = true;
+			}
+			else
+			{
+				South( f );
+				East( e );
+
+				trees[3] = true;
+			}
+		}
+		else
+		{
+			West( e );
+			East( d );
+
+			trees[7] = true;
+		}
+	}
+	else
+	{
+		// start position
+		if ( gotKey1 )
+		{
+			North( a );
+		}
+
+		East( b );
+		South( c );
+		West( d );
+		
+		walls[0] = walls[2] = true;
+		trees[6] = trees[8] = true;
+
+		drawDoor1 = true;
+	}
+	
+	if ( !win )
+	{
+		if ( paved )
+			DrawPaving();
+		else
+			DrawDirt();
+	
+		// special items
+		if ( drawDoor1 ) DrawDoor( vec2(0,120), Key1Col() );
+		if ( drawDoor2 ) DrawDoor( vec2(0,120), Key2Col() );
+	
+		if ( drawKey1 )
+		{
+			DrawChar( vec2(0,20), K );
+			DrawKey( vec2(0,0), Key1Col() );
+		}
+	
+		if ( drawKey2 )
+		{
+			DrawChar( vec2(0,20), H );
+			DrawKey( vec2(0,0), Key2Col() );
+		}
+		
+		if ( trees[0] ) DrawTrees( vec2(-120, 120) );
+		if ( trees[1] ) DrawTrees( vec2(   0, 120) );
+		if ( trees[2] ) DrawTrees( vec2( 120, 120) );
+		if ( trees[3] ) DrawTrees( vec2(-120,   0) );
+		if ( trees[4] ) DrawTrees( vec2(   0,   0) );
+		if ( trees[5] ) DrawTrees( vec2( 120,   0) );
+		if ( trees[6] ) DrawTrees( vec2(-120,-120) );
+		if ( trees[7] ) DrawTrees( vec2(   0,-120) );
+		if ( trees[8] ) DrawTrees( vec2( 120,-120) );
+		
+		if ( walls[0] ) DrawWalls( vec2(-120, 120) );
+		if ( walls[1] ) DrawWalls( vec2(   0, 120) );
+		if ( walls[2] ) DrawWalls( vec2( 120, 120) );
+		if ( walls[3] ) DrawWalls( vec2(-120,   0) );
+		if ( walls[4] ) DrawWalls( vec2(   0,   0) );
+		if ( walls[5] ) DrawWalls( vec2( 120,   0) );
+		if ( walls[6] ) DrawWalls( vec2(-120,-120) );
+		if ( walls[7] ) DrawWalls( vec2(   0,-120) );
+		if ( walls[8] ) DrawWalls( vec2( 120,-120) );
+		
+		DrawChar( a, A );
+		DrawChar( b, B );
+		DrawChar( c, C );
+		DrawChar( d, D );
+		DrawChar( e, E );
+		DrawChar( f, F );
+		DrawChar( g, G );
+	}
+	else
+	{
+		// Success!
+		fragColor.rgb = .5+.5*sin(length(pixel)*.1-vec3(1,1.1,1.13)*4.0*iTime);
+		
+		s_textCol = vec3(1,sin(iTime*11.0)*.5+.5,sin(iTime*8.0)*.5+.5);
+		PrintPos( vec2(-80,20) );
+		Print( c_,Y,O,U,c_,W,I,N,c_ );
+		NewLine();
+		NewLine();
+		Print( G,A,M,E,c_,O,V,E,R );
+	}
+	
+	fragColor.rgb = pow(fragColor.rgb,vec3(1.0/2.2));
+    
+    oFragColor = fragColor;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -715,7 +715,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
         const config = vscode.workspace.getConfiguration('shader-toy');
 
-        var line_offset = 122;
+        var line_offset = 123;
         var textures = [];
         let includeName = '';
 
@@ -758,11 +758,13 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         LineCount: shaderFile.bufferCode.split(/\r\n|\n/).length
                     };
 
+
                     commonIncludes.push(include);
                 }
 
                 // offset the include line count
-                line_offset += include.LineCount;
+                // TODO: Why do we need to subtract one here?
+                line_offset += include.LineCount - 1;
 
                 // store the reference name for this include
                 includeName = name;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,97 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
         
 
+        let useKeyboard = false;
+        for (let i in buffers) {
+            const buffer = buffers[i];
+            if (buffer.UsesKeyboard) {
+                useKeyboard = true;
+            }
+        }
+
+        let keyboard = {
+            Init: "",
+            Update: "",
+            Callbacks: "",
+            Shader: "",
+            LineOffset: 0
+        };
+        if (useKeyboard) {
+            keyboard.Init = `
+            const numKeys = 256;
+            const numStates = 4;
+            var keyBoardData = new Uint8Array(numKeys * numStates);
+            var keyBoardTexture = new THREE.DataTexture(keyBoardData, numKeys, numStates, THREE.LuminanceFormat, THREE.UnsignedByteType);
+            keyBoardTexture.magFilter = THREE.NearestFilter;
+            keyBoardTexture.flipY = true;
+            keyBoardTexture.needsUpdate = true;
+            var pressedKeys = [];
+            var releasedKeys = [];`;
+
+            keyboard.Update = `
+            // Update keyboard data
+            if (pressedKeys.length > 0 || releasedKeys.length > 0) {
+                for (let i in pressedKeys)
+                    keyBoardData[pressedKeys[i] + 256] = 0;
+                for (let i in releasedKeys)
+                    keyBoardData[releasedKeys[i] + 768] = 0;
+                keyBoardTexture.needsUpdate = true;
+                pressedKeys = [];
+                releasedKeys = [];
+            }`;
+
+            keyboard.Callbacks = `
+            document.addEventListener('keydown', function(evt) {
+                const i = evt.keyCode;
+                if (i >= 0 && i <= 255) {
+                    // Key is being held, don't register input
+                    if (keyBoardData[i + 512] == 0) {
+                        keyBoardData[i] = (keyBoardData[i] == 255 ? 0 : 255);
+                        keyBoardData[i + 256] = 255;
+                        keyBoardData[i + 512] = 255;
+                        pressedKeys.push(i);
+                        keyBoardTexture.needsUpdate = true;
+                    }
+                }
+            });
+            document.addEventListener('keyup', function(evt) {
+                const i = evt.keyCode;
+                if (i >= 0 && i <= 255) {
+                    keyBoardData[i + 512] = 0;
+                    keyBoardData[i + 768] = 255;
+                    releasedKeys.push(i);
+                    keyBoardTexture.needsUpdate = true;
+                }
+            });`;
+            
+            keyboard.Shader = `
+            const int Key_Backspace = 8, Key_Tab = 9, Key_Enter = 13, Key_Shift = 16, Key_Ctrl = 17, Key_Alt = 18, Key_Pause = 19, Key_Caps = 20, Key_Escape = 27, Key_PageUp = 33, Key_PageDown = 34, Key_End = 35,
+                Key_Home = 36, Key_LeftArrow = 37, Key_UpArrow = 38, Key_RightArrow = 39, Key_DownArrow = 40, Key_Insert = 45, Key_Delete = 46, Key_0 = 48, Key_1 = 49, Key_2 = 50, Key_3 = 51, Key_4 = 52,
+                Key_5 = 53, Key_6 = 54, Key_7 = 55, Key_8 = 56, Key_9 = 57, Key_A = 65, Key_B = 66, Key_C = 67, Key_D = 68, Key_E = 69, Key_F = 70, Key_G = 71, Key_H = 72,
+                Key_I = 73, Key_J = 74, Key_K = 75, Key_L = 76, Key_M = 77, Key_N = 78, Key_O = 79, Key_P = 80, Key_Q = 81, Key_R = 82, Key_S = 83, Key_T = 84, Key_U = 85,
+                Key_V = 86, Key_W = 87, Key_X = 88, Key_Y = 89, Key_Z = 90, Key_LeftWindow = 91, Key_RightWindows = 92, Key_Select = 93, Key_Numpad0 = 96, Key_Numpad1 = 97, Key_Numpad2 = 98, Key_Numpad3 = 99,
+                Key_Numpad4 = 100, Key_Numpad5 = 101, Key_Numpad6 = 102, Key_Numpad7 = 103, Key_Numpad8 = 104, Key_Numpad9 = 105, Key_NumpadMultiply = 106, Key_NumpadAdd = 107, Key_NumpadSubtract = 109, Key_NumpadPeriod = 110, Key_NumpadDivide = 111, Key_F1 = 112, Key_F2 = 113, Key_F3 = 114, Key_F4 = 115, Key_F5 = 116, Key_F6 = 117, Key_F7 = 118, Key_F8 = 119, Key_F9 = 120, Key_F10 = 121, Key_F11 = 122, Key_F12 = 123, Key_NumLock = 144, Key_ScrollLock = 145,
+                Key_SemiColon = 186, Key_Equal = 187, Key_Comma = 188, Key_Dash = 189, Key_Period = 190, Key_ForwardSlash = 191, Key_GraveAccent = 192, Key_OpenBracket = 219, Key_BackSlash = 220, Key_CloseBraket = 221, Key_SingleQuote = 222;
+
+            bool isKeyToggled(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.875);
+                return texture2D(iKeyboard, uv).r > 0.0;
+            }
+            bool isKeyPressed(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.625);
+                return texture2D(iKeyboard, uv).r > 0.0;
+            }
+            bool isKeyDown(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.375);
+                return texture2D(iKeyboard, uv).r > 0.0;
+            }
+            bool isKeyReleased(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.125);
+                return texture2D(iKeyboard, uv).r > 0.0;
+            }`;
+            keyboard.LineOffset = keyboard.Shader.split(/\r\n|\n/).length - 1;
+        }
+
         // Write all the shaders
         var shaderScripts = "";
         var buffersScripts = "";
@@ -161,6 +252,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             shaderScripts += `
             <script id="${buffer.Name}" type="x-shader/x-fragment">
                 ${shaderPreamble}
+                ${keyboard.Shader}
                 ${include ? include.Code : ''}
                 ${buffer.Code}
             </script>`
@@ -172,6 +264,9 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 target = "new THREE.WebGLRenderTarget(canvas.clientWidth, canvas.clientHeight, { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, type: framebufferType })";
             if (buffer.UsesSelf)
                 pingPongTarget = "new THREE.WebGLRenderTarget(canvas.clientWidth, canvas.clientHeight, { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, type: framebufferType })";
+
+            if (buffer.UsesKeyboard)
+                buffer.LineOffset += keyboard.LineOffset;
 
             buffersScripts += `
             buffers.push({
@@ -216,9 +311,12 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 });`;
         }
         
-        var useKeyboard = false;
-        var textureScripts = "\n";
-        var textureLoadScript = `function(texture){ texture.minFilter = THREE.LinearFilter; }`;
+        let textureScripts = "\n";
+        let textureLoadScript = `function(texture) {
+            texture.minFilter = THREE.LinearFilter;
+            texture.wrapS = THREE.RepeatWrapping;
+            texture.wrapT = THREE.RepeatWrapping;
+        }`;
         for (let i in buffers) {
             const buffer = buffers[i];
             const textures =  buffer.Textures;
@@ -229,7 +327,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 const texturePath = texture.LocalTexture;
                 const textureUrl = texture.RemoteTexture;
 
-                var value: string;
+                let value: string;
                 if (bufferIndex != null)
                     value = `buffers[${bufferIndex}].Target.texture`;
                 else if (texturePath != null)
@@ -287,58 +385,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             } else {
                 deltaTime = 0.0;
             }`;
-        }
-
-        var keyboardInitScript = "";
-        var keyboardUpdateScript = "";
-        var keyboardCallbackScripts = "";
-        if (useKeyboard) {
-            keyboardInitScript = `
-            const numKeys = 256;
-            const numStates = 4;
-            var keyBoardData = new Uint8Array(numKeys * numStates);
-            var keyBoardTexture = new THREE.DataTexture(keyBoardData, numKeys, numStates, THREE.LuminanceFormat, THREE.UnsignedByteType);
-            keyBoardTexture.magFilter = THREE.NearestFilter;
-            keyBoardTexture.flipY = true;
-            keyBoardTexture.needsUpdate = true;
-            var pressedKeys = [];
-            var releasedKeys = [];`;
-
-            keyboardUpdateScript = `
-            // Update keyboard data
-            if (pressedKeys.length > 0 || releasedKeys.length > 0) {
-                for (let i in pressedKeys)
-                    keyBoardData[pressedKeys[i] + 256] = 0;
-                for (let i in releasedKeys)
-                    keyBoardData[releasedKeys[i] + 768] = 0;
-                keyBoardTexture.needsUpdate = true;
-                pressedKeys = [];
-                releasedKeys = [];
-            }`;
-
-            keyboardCallbackScripts = `
-            document.addEventListener('keydown', function(evt) {
-                const i = evt.keyCode;
-                if (i >= 0 && i <= 255) {
-                    // Key is being held, don't register input
-                    if (keyBoardData[i + 512] == 0) {
-                        keyBoardData[i] = (keyBoardData[i] == 255 ? 0 : 255);
-                        keyBoardData[i + 256] = 255;
-                        keyBoardData[i + 512] = 255;
-                        pressedKeys.push(i);
-                        keyBoardTexture.needsUpdate = true;
-                    }
-                }
-            });
-            document.addEventListener('keyup', function(evt) {
-                const i = evt.keyCode;
-                if (i >= 0 && i <= 255) {
-                    keyBoardData[i + 512] = 0;
-                    keyBoardData[i + 768] = 255;
-                    releasedKeys.push(i);
-                    keyBoardTexture.needsUpdate = true;
-                }
-            });`;
         }
 
         // http://threejs.org/docs/api/renderers/webgl/WebGLProgram.html
@@ -507,7 +553,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                     }
                 }
 
-                ${keyboardInitScript}
+                ${keyboard.Init}
                 
                 var texLoader = new THREE.TextureLoader();
                 ${textureScripts}
@@ -629,7 +675,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         }
                     }
 
-                    ${keyboardUpdateScript}
+                    ${keyboard.Update}
                 }
                 let dragging = false;
                 function updateMouse(clientX, clientY) {
@@ -662,7 +708,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                     dragging = false;
                 }, false);
 
-                ${keyboardCallbackScripts}
+                ${keyboard.Callbacks}
             </script>
         `;
         // console.log(shaderScripts);
@@ -715,7 +761,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
         const config = vscode.workspace.getConfiguration('shader-toy');
 
-        var line_offset = 123;
+        var line_offset = 124;
         var textures = [];
         let includeName = '';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,8 +153,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         
 
         let useKeyboard = false;
-        for (let i in buffers) {
-            const buffer = buffers[i];
+        for (let buffer of buffers) {
             if (buffer.UsesKeyboard) {
                 useKeyboard = true;
             }
@@ -182,10 +181,10 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             keyboard.Update = `
             // Update keyboard data
             if (pressedKeys.length > 0 || releasedKeys.length > 0) {
-                for (let i in pressedKeys)
-                    keyBoardData[pressedKeys[i] + 256] = 0;
-                for (let i in releasedKeys)
-                    keyBoardData[releasedKeys[i] + 768] = 0;
+                for (let key of pressedKeys)
+                    keyBoardData[key + 256] = 0;
+                for (let key of releasedKeys)
+                    keyBoardData[key + 768] = 0;
                 keyBoardTexture.needsUpdate = true;
                 pressedKeys = [];
                 releasedKeys = [];
@@ -246,8 +245,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         // Write all the shaders
         var shaderScripts = "";
         var buffersScripts = "";
-        for (let i in buffers) {
-            const buffer = buffers[i];
+        for (let buffer of buffers) {
             const include = buffer.IncludeName ? commonIncludes.find(include => include.Name == buffer.IncludeName) : ''
             shaderScripts += `
             <script id="${buffer.Name}" type="x-shader/x-fragment">
@@ -294,8 +292,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
 
         // add the common includes for compilation checking
-        for(let i in commonIncludes) {
-            const include = commonIncludes[i];
+        for (let include of commonIncludes) {
             shaderScripts += `
                 <script id="${include.Name}" type="x-shader/x-fragment">#version 300 es
                     precision highp float;
@@ -320,8 +317,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         for (let i in buffers) {
             const buffer = buffers[i];
             const textures =  buffer.Textures;
-            for (let j in textures) {
-                const texture = textures[j];
+            for (let texture of textures) {
                 const channel = texture.Channel;
                 const bufferIndex = texture.BufferIndex;
                 const texturePath = texture.LocalTexture;
@@ -548,8 +544,8 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
                 // WebGL2 inserts more lines into the shader
                 if (isWebGL2) {
-                    for (let i in buffers) {
-                        buffers[i].LineOffset += 16;
+                    for (let buffer of buffers) {
+                        buffer.LineOffset += 16;
                     }
                 }
 
@@ -570,8 +566,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
 
                 // Run every shader once to check for compile errors
                 let failed=0;
-                for(let i in commonIncludes) {
-                    let include = commonIncludes[i];
+                for (let include of commonIncludes) {
                     currentShader = {
                         Name: include.Name,
                         File: include.File,
@@ -581,8 +576,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                     if(compileFragShader(gl, document.getElementById(include.Name).textContent) == false) throw Error(\`Failed to compile \${include.Name}\`);
                 }
 
-                for (let i in buffers) {
-                    let buffer = buffers[i];
+                for (let buffer of buffers) {
                     currentShader = {
                         Name: buffer.Name,
                         File: buffer.File,
@@ -622,8 +616,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                     if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
                         resolution.x = canvas.clientWidth;
                         resolution.y = canvas.clientHeight;
-                        for (let i in buffers) {
-                            let buffer = buffers[i];
+                        for (let buffer of buffers) {
                             if (buffer.Target) {
                                 buffer.Target.setSize(resolution.x, resolution.y);
                             }
@@ -648,9 +641,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                     frameCounter++;
                     ${advanceTimeScript}
 
-                    for (let i in buffers) {
-                        const buffer = buffers[i];
-
+                    for (let buffer of buffers) {
                         buffer.Shader.uniforms['iResolution'].value = resolution;
                         buffer.Shader.uniforms['iTimeDelta'].value = deltaTime;
                         buffer.Shader.uniforms['iGlobalTime'].value = time;
@@ -662,13 +653,11 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                         renderer.render(scene, camera, buffer.Target);
                     }
 
-                    for (let i in buffers) {
-                        const buffer = buffers[i];
+                    for (let buffer of buffers) {
                         if (buffer.PingPongTarget) {
                             [buffer.PingPongTarget, buffer.Target] = [buffer.Target, buffer.PingPongTarget];
                             buffer.Shader.uniforms[\`iChannel\${buffer.PingPongChannel}\`].value = buffer.PingPongTarget.texture;
-                            for (let j in buffer.Dependents) {
-                                const dependent = buffer.Dependents[j];
+                            for (let dependent of buffer.Dependents) {
                                 const dependentBuffer = buffers[dependent.Index];
                                 dependentBuffer.Shader.uniforms[\`iChannel\${dependent.Channel}\`] = { type: 't', value: buffer.Target.texture };
                             }
@@ -915,7 +904,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
         else { // TODO: Ideally depracate this because it is counter-productive when working dependent shaders
             let textures = config.get('textures');
-            for(let i in textures) {
+            for (let i in textures) {
                 const texture = textures[i];
                 if (textures[i].length > 0) {
                     // Check for buffer to load to avoid circular loading
@@ -938,8 +927,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         }
 
         var definedTextures = {};
-        for (let i in textures) {
-            const texture = textures[i];
+        for (let texture of textures) {
             definedTextures[texture.Channel] = true;
         }
         if (config.get<boolean>('warnOnUndefinedTextures')) {
@@ -966,7 +954,7 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
         // Translate buffer names to indices
         var usesSelf = false;
         var selfChannel = 0;
-        for (var i = 0; i < textures.length; i++) {
+        for (let i = 0; i < textures.length; i++) {
             let texture = textures[i];
             if (texture.Buffer) {
                 texture.BufferIndex = buffers.findIndex(findByName(texture.Buffer));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,6 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             var keyBoardData = new Uint8Array(numKeys * numStates);
             var keyBoardTexture = new THREE.DataTexture(keyBoardData, numKeys, numStates, THREE.LuminanceFormat, THREE.UnsignedByteType);
             keyBoardTexture.magFilter = THREE.NearestFilter;
-            keyBoardTexture.flipY = true;
             keyBoardTexture.needsUpdate = true;
             var pressedKeys = [];
             var releasedKeys = [];`;
@@ -195,10 +194,10 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 const i = evt.keyCode;
                 if (i >= 0 && i <= 255) {
                     // Key is being held, don't register input
-                    if (keyBoardData[i + 512] == 0) {
-                        keyBoardData[i] = (keyBoardData[i] == 255 ? 0 : 255);
-                        keyBoardData[i + 256] = 255;
-                        keyBoardData[i + 512] = 255;
+                    if (keyBoardData[i] == 0) {
+                        keyBoardData[i] = 255; // Held
+                        keyBoardData[i + 256] = 255; // Pressed
+                        keyBoardData[i + 512] = (keyBoardData[i + 512] == 255 ? 0 : 255); // Toggled
                         pressedKeys.push(i);
                         keyBoardTexture.needsUpdate = true;
                     }
@@ -207,8 +206,8 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
             document.addEventListener('keyup', function(evt) {
                 const i = evt.keyCode;
                 if (i >= 0 && i <= 255) {
-                    keyBoardData[i + 512] = 0;
-                    keyBoardData[i + 768] = 255;
+                    keyBoardData[i] = 0; // Not held
+                    keyBoardData[i + 768] = 255; // Released
                     releasedKeys.push(i);
                     keyBoardTexture.needsUpdate = true;
                 }
@@ -223,20 +222,20 @@ class GLSLDocumentContentProvider implements TextDocumentContentProvider {
                 Key_Numpad4 = 100, Key_Numpad5 = 101, Key_Numpad6 = 102, Key_Numpad7 = 103, Key_Numpad8 = 104, Key_Numpad9 = 105, Key_NumpadMultiply = 106, Key_NumpadAdd = 107, Key_NumpadSubtract = 109, Key_NumpadPeriod = 110, Key_NumpadDivide = 111, Key_F1 = 112, Key_F2 = 113, Key_F3 = 114, Key_F4 = 115, Key_F5 = 116, Key_F6 = 117, Key_F7 = 118, Key_F8 = 119, Key_F9 = 120, Key_F10 = 121, Key_F11 = 122, Key_F12 = 123, Key_NumLock = 144, Key_ScrollLock = 145,
                 Key_SemiColon = 186, Key_Equal = 187, Key_Comma = 188, Key_Dash = 189, Key_Period = 190, Key_ForwardSlash = 191, Key_GraveAccent = 192, Key_OpenBracket = 219, Key_BackSlash = 220, Key_CloseBraket = 221, Key_SingleQuote = 222;
 
-            bool isKeyToggled(int key) {
-                vec2 uv = vec2(float(key) / 255.0, 0.875);
+            bool isKeyDown(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.125);
                 return texture2D(iKeyboard, uv).r > 0.0;
             }
             bool isKeyPressed(int key) {
-                vec2 uv = vec2(float(key) / 255.0, 0.625);
-                return texture2D(iKeyboard, uv).r > 0.0;
-            }
-            bool isKeyDown(int key) {
                 vec2 uv = vec2(float(key) / 255.0, 0.375);
                 return texture2D(iKeyboard, uv).r > 0.0;
             }
+            bool isKeyToggled(int key) {
+                vec2 uv = vec2(float(key) / 255.0, 0.625);
+                return texture2D(iKeyboard, uv).r > 0.0;
+            }
             bool isKeyReleased(int key) {
-                vec2 uv = vec2(float(key) / 255.0, 0.125);
+                vec2 uv = vec2(float(key) / 255.0, 0.875);
                 return texture2D(iKeyboard, uv).r > 0.0;
             }`;
             keyboard.LineOffset = keyboard.Shader.split(/\r\n|\n/).length - 1;

--- a/src/preview.html
+++ b/src/preview.html
@@ -174,6 +174,8 @@
         vec3 pattern = texture2D(iChannel0, uvWarped).rgb;
 
         gl_FragColor = vec4(pattern, 1.0);
+
+        gl_FragColor = vec4(texture(iChannel2, uv).r, 0.0, 0.0, 1.0);
     }
 </script>
 
@@ -266,10 +268,21 @@
             buffers[i].LineOffset += 16;
         }
     }
+
+    const numKeys = 256;
+    const numStates = 4;
+    var keyBoardData = new Uint8Array(numKeys * numStates);
+    var keyBoardTexture = new THREE.DataTexture(keyBoardData, numKeys, numStates, THREE.LuminanceFormat, THREE.UnsignedByteType);
+    keyBoardTexture.magFilter = THREE.NearestFilter;
+    keyBoardTexture.flipY = true;
+    keyBoardTexture.needsUpdate = true;
+    var pressedKeys = [];
+    var releasedKeys = [];
     
     var texLoader = new THREE.TextureLoader();
     buffers[1].Shader.uniforms.iChannel0 = { type: 't', value: texLoader.load('https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg', function(texture){ texture.minFilter = THREE.LinearFilter; }) };
     buffers[1].Shader.uniforms.iChannel1 = { type: 't', value: buffers[0].Target.texture };
+    buffers[1].Shader.uniforms.iChannel2 = { type: 't', value: keyBoardTexture };
 
     var scene = new THREE.Scene();
     var quad = new THREE.Mesh(
@@ -335,6 +348,17 @@
             quad.material = buffer.Shader;
             renderer.render(scene, camera, buffer.Target);
         }
+
+        // Update keyboard data
+        if (pressedKeys.length > 0 || releasedKeys.length > 0) {
+            for (let i in pressedKeys)
+                keyBoardData[pressedKeys[i] + 256] = 0;
+            for (let i in releasedKeys)
+                keyBoardData[releasedKeys[i] + 768] = 0;
+            keyBoardTexture.needsUpdate = true;
+            pressedKeys = [];
+            releasedKeys = [];
+        }
     }
     canvas.addEventListener('mousemove', function(evt) {
         if (mouse.z + mouse.w != 0) {
@@ -355,4 +379,26 @@
         if (evt.button == 2)
             mouse.w = 0;
     }, false);
+    document.addEventListener('keydown', function(evt) {
+        const i = evt.keyCode;
+        if (i >= 0 && i <= 255) {
+            // Key is being held, don't register input
+            if (keyBoardData[i + 512] == 0) {
+                keyBoardData[i] = (keyBoardData[i] == 255 ? 0 : 255);
+                keyBoardData[i + 256] = 255;
+                keyBoardData[i + 512] = 255;
+                pressedKeys.push(i);
+                keyBoardTexture.needsUpdate = true;
+            }
+        }
+    });
+    document.addEventListener('keyup', function(evt) {
+        const i = evt.keyCode;
+        if (i >= 0 && i <= 255) {
+            keyBoardData[i + 512] = 0;
+            keyBoardData[i + 768] = 255;
+            releasedKeys.push(i);
+            keyBoardTexture.needsUpdate = true;
+        }
+    });
 </script>


### PR DESCRIPTION
Added support for keyboard input through prepending ```#iKeyboard``` to the shader. See Readme.md for more details.
Since shadertoy.com supports this officially via texelFetch (which we can't because we support WebGL 1.0 and 2.0 for now) I don't think that adding the release state breaks compatibility with shadertoy.com. However for use only the texture iKeyboard is available for querrying manually, while for shadertoy.com any channel can be used. I still don't consider this a break in compatibility since it is a find and replace work only.
This will close #33 