### PR TITLE
Webview API

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"ms-vscode.vscode-typescript-tslint-plugin"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,35 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-    "version": "0.1.0",
-    "configurations": [
-        {
-            "name": "Launch Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src",
-            "preLaunchTask": "npm"
-        },
-        {
-            "name": "Launch Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/test",
-            "preLaunchTask": "npm"
-        }
-    ]
+	"version": "0.2.0",
+	"configurations": [{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: watch"
+		},
+		{
+			"name": "Extension Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm: watch"
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
-  }
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,20 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,47 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+        "@types/mocha": {
+            "version": "2.2.48",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+            "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
             "dev": true
+        },
+        "@types/node": {
+            "version": "10.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
+            "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -22,13 +58,28 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
             "dev": true
         },
-        "arr-diff": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.0.1"
+                "buffer-equal": "^1.0.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-flatten": {
@@ -37,16 +88,22 @@
             "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
             "dev": true
         },
+        "arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+            "dev": true
+        },
         "array-differ": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
             "dev": true
         },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+        "array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
             "dev": true
         },
         "array-union": {
@@ -55,19 +112,13 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "arrify": {
@@ -77,25 +128,19 @@
             "dev": true
         },
         "asn1": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-            "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-            "dev": true
-        },
-        "assert-plus": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-            "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-            "dev": true
-        },
-        "async": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-            "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.4"
+                "safer-buffer": "~2.1.0"
             }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -104,66 +149,41 @@
             "dev": true
         },
         "aws-sign2": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-            "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
             "dev": true
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
         },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            }
+        },
         "balanced-match": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
         "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "tweetnacl": "0.14.5"
-            }
-        },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
-        },
-        "bl": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-            "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.0.34"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                }
+                "tweetnacl": "^0.14.3"
             }
         },
         "block-stream": {
@@ -172,49 +192,41 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
-            }
-        },
-        "bluebird": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-            "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-            "dev": true
-        },
-        "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true,
-            "requires": {
-                "hoek": "2.16.3"
+                "inherits": "~2.0.0"
             }
         },
         "brace-expansion": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-            "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-        "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true,
-            "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-            }
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
         },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
         "buffer-shims": {
@@ -229,26 +241,10 @@
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
         },
-        "camelcase": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-            "dev": true
-        },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
-            }
-        },
         "caseless": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-            "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk=",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
         "chalk": {
@@ -257,17 +253,17 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
-        "clone": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
             "dev": true
         },
         "clone-stats": {
@@ -276,22 +272,71 @@
             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
             "dev": true
         },
-        "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+        "cloneable-readable": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+            "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
-        "commander": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
             "requires": {
-                "graceful-readlink": "1.0.1"
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
             }
         },
         "concat-map": {
@@ -300,41 +345,11 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "convert-source-map": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
-            "integrity": "sha1-49rRlb9hv+E6ejxz6YduwUoCaPM=",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
-        },
-        "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1"
-            }
-        },
-        "ctype": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-            "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-            "dev": true
-        },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "1.0.2"
-            }
         },
         "dashdash": {
             "version": "1.14.1",
@@ -342,37 +357,8 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "assert-plus": "^1.0.0"
             }
-        },
-        "dateformat": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
-            "dev": true
-        },
-        "debug": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-            "dev": true,
-            "requires": {
-                "ms": "0.7.1"
-            }
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
         },
         "deep-assign": {
             "version": "1.0.0",
@@ -380,7 +366,24 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            },
+            "dependencies": {
+                "object-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+                    "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+                    "dev": true
+                }
             }
         },
         "delayed-stream": {
@@ -389,67 +392,20 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
-        "diff": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-            "dev": true
-        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "1.1.14"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                }
-            }
-        },
-        "duplexify": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-            "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.3",
-                "stream-shift": "1.0.0"
-            }
-        },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
-            "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -458,7 +414,7 @@
             "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
             "dev": true,
             "requires": {
-                "once": "1.3.3"
+                "once": "~1.3.0"
             },
             "dependencies": {
                 "once": {
@@ -467,18 +423,9 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
-            }
-        },
-        "error-ex": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-            "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "0.2.1"
             }
         },
         "escape-string-regexp": {
@@ -487,70 +434,23 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "event-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-            "integrity": "sha1-tMVAAS0P4UmEIPPYlGAI22OTw3o=",
-            "dev": true,
-            "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.3",
-                "map-stream": "0.1.0",
-                "pause-stream": "0.0.11",
-                "split": "0.2.10",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
-            }
-        },
-        "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true,
-            "requires": {
-                "is-posix-bracket": "0.1.1"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "2.2.3"
-            }
-        },
-        "extend": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-            "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA=",
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
-        "extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-            "dev": true,
-            "requires": {
-                "is-extendable": "0.1.1"
-            }
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
         },
-        "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
-            "requires": {
-                "is-extglob": "1.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                }
-            }
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extsprintf": {
             "version": "1.0.2",
@@ -558,15 +458,17 @@
             "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
             "dev": true
         },
-        "fancy-log": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "time-stamp": "1.0.1"
-            }
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
         },
         "fd-slicer": {
             "version": "1.0.1",
@@ -574,57 +476,49 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
-        "filename-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-            "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
-            "dev": true
-        },
-        "fill-range": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.6",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
-            }
-        },
-        "find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
-            "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "for-in": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-            "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg=",
-            "dev": true
-        },
-        "for-own": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-            "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
-            "dev": true,
-            "requires": {
-                "for-in": "0.1.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "forever-agent": {
@@ -634,25 +528,14 @@
             "dev": true
         },
         "form-data": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-            "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "async": "2.1.5",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.14"
-            },
-            "dependencies": {
-                "mime-types": {
-                    "version": "2.1.14",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-                    "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.26.0"
-                    }
-                }
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -661,120 +544,35 @@
             "integrity": "sha1-72OsIGKsMqz3hi4NQLRLiW8i87w=",
             "dev": true
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "fstream": {
-            "version": "0.1.31",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-            "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "3.0.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.0"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "3.0.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "1.1.0"
-                    }
-                }
-            }
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
-            }
-        },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
         "getpass": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-            "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
-            }
-        },
-        "glob": {
-            "version": "5.0.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-            "dev": true,
-            "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-            }
-        },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "assert-plus": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -783,69 +581,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
-            }
-        },
-        "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-            "dev": true,
-            "requires": {
-                "extend": "3.0.0",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                    "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
-        "glogg": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -854,505 +591,29 @@
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-            "dev": true
-        },
-        "growl": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-            "dev": true
-        },
-        "gulp-chmod": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-1.3.0.tgz",
-            "integrity": "sha1-i7bowRiV3L+bQlIMh0NHpQIryw0=",
-            "dev": true,
-            "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
-            }
-        },
-        "gulp-filter": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-4.0.0.tgz",
-            "integrity": "sha1-OV9YolbFWc254NFX8cqvUkijjcs=",
-            "dev": true,
-            "requires": {
-                "gulp-util": "3.0.8",
-                "multimatch": "2.1.0",
-                "streamfilter": "1.0.5"
-            }
-        },
-        "gulp-gunzip": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
-            "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
-            "dev": true,
-            "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-remote-src": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.1.tgz",
-            "integrity": "sha1-bDYATlcijJ3wL76pcnqGFrr4c1U=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.1.7",
-                "node.extend": "1.1.6",
-                "request": "2.58.0",
-                "through2": "0.5.1",
-                "vinyl": "0.2.3"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "request": {
-                    "version": "2.58.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
-                    "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.5.0",
-                        "bl": "0.9.5",
-                        "caseless": "0.10.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "2.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "1.0.1",
-                        "har-validator": "1.8.0",
-                        "hawk": "2.3.1",
-                        "http-signature": "0.11.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.0.14",
-                        "node-uuid": "1.4.7",
-                        "oauth-sign": "0.8.2",
-                        "qs": "3.1.0",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.4.3"
-                    }
-                },
-                "through2": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                    "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "3.0.0"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                    "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-                    "dev": true,
-                    "requires": {
-                        "clone-stats": "0.0.1"
-                    }
-                },
-                "xtend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "1.4.0",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
-            },
-            "dependencies": {
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.2",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+        "gulp-remote-src-vscode": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
+            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
-            },
-            "dependencies": {
-                "event-stream": {
-                    "version": "3.3.4",
-                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-                    "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-                    "dev": true,
-                    "requires": {
-                        "duplexer": "0.1.1",
-                        "from": "0.1.3",
-                        "map-stream": "0.1.0",
-                        "pause-stream": "0.0.11",
-                        "split": "0.3.3",
-                        "stream-combiner": "0.0.4",
-                        "through": "2.3.8"
-                    }
-                },
-                "split": {
-                    "version": "0.3.3",
-                    "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-                    "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-                    "dev": true,
-                    "requires": {
-                        "through": "2.3.8"
-                    }
-                }
-            }
-        },
-        "gulp-untar": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.4.tgz",
-            "integrity": "sha1-Y1zH1n09SK7A28aYImI/x8M/fTc=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.1.7",
-                "gulp-util": "2.2.20",
-                "streamifier": "0.1.1",
-                "tar": "0.1.20",
-                "through2": "0.4.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
-                    }
-                },
-                "dateformat": {
-                    "version": "1.0.12",
-                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                    "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-                    "dev": true,
-                    "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
-                    }
-                },
-                "gulp-util": {
-                    "version": "2.2.20",
-                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-                    "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "0.5.1",
-                        "dateformat": "1.0.12",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.template": "2.4.1",
-                        "minimist": "0.2.0",
-                        "multipipe": "0.1.2",
-                        "through2": "0.5.1",
-                        "vinyl": "0.2.3"
-                    },
-                    "dependencies": {
-                        "through2": {
-                            "version": "0.5.1",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                            "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "has-ansi": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "0.2.1"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "lodash._reinterpolate": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                    "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
-                    "dev": true
-                },
-                "lodash.escape": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                    "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._escapehtmlchar": "2.4.1",
-                        "lodash._reunescapedhtml": "2.4.1",
-                        "lodash.keys": "2.4.1"
-                    }
-                },
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
-                    }
-                },
-                "lodash.template": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                    "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._escapestringchar": "2.4.1",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.defaults": "2.4.1",
-                        "lodash.escape": "2.4.1",
-                        "lodash.keys": "2.4.1",
-                        "lodash.templatesettings": "2.4.1",
-                        "lodash.values": "2.4.1"
-                    }
-                },
-                "lodash.templatesettings": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                    "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.escape": "2.4.1"
-                    }
-                },
-                "minimist": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-                    "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "0.2.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-                    "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "2.1.2"
-                    },
-                    "dependencies": {
-                        "xtend": {
-                            "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-                            "dev": true,
-                            "requires": {
-                                "object-keys": "0.4.0"
-                            }
-                        }
-                    }
-                },
-                "vinyl": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                    "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-                    "dev": true,
-                    "requires": {
-                        "clone-stats": "0.0.1"
-                    }
-                },
-                "xtend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.0.0",
-                "fancy-log": "1.3.0",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
-            }
-        },
-        "gulp-vinyl-zip": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
-            "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "queue": "3.1.0",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.7.0",
-                "yazl": "2.4.2"
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
                 "event-stream": {
@@ -1361,32 +622,20 @@
                     "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
                     "dev": true,
                     "requires": {
-                        "duplexer": "0.1.1",
-                        "from": "0.1.3",
-                        "map-stream": "0.1.0",
+                        "duplexer": "~0.1.1",
+                        "from": "~0",
+                        "map-stream": "~0.1.0",
                         "pause-stream": "0.0.11",
-                        "split": "0.3.3",
-                        "stream-combiner": "0.0.4",
-                        "through": "2.3.8"
+                        "split": "0.3",
+                        "stream-combiner": "~0.0.4",
+                        "through": "~2.3.1"
                     }
                 },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
                     "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
                 },
                 "split": {
                     "version": "0.3.3",
@@ -1394,50 +643,48 @@
                     "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
                     "dev": true,
                     "requires": {
-                        "through": "2.3.8"
-                    }
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "through": "2"
                     }
                 },
                 "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
         },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "1.0.0"
-            }
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
         },
         "har-validator": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-            "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.15.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -1446,60 +693,36 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
-        },
-        "hawk": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-            "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-            }
-        },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
-        "hosted-git-info": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-            "integrity": "sha1-eg0JeGPYhsD6u9zTe/F1jYvs+KU=",
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "http-signature": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-            "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "asn1": "0.1.11",
-                "assert-plus": "0.1.5",
-                "ctype": "0.5.3"
-            }
-        },
-        "indent-string": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "dev": true,
-            "requires": {
-                "repeating": "2.0.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1508,8 +731,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1519,52 +742,20 @@
             "dev": true
         },
         "is": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/is/-/is-3.2.0.tgz",
-            "integrity": "sha1-o2Lj2vffP9i3EUEV1iTFt+HLkPc=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+            "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "dev": true
         },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
-        },
-        "is-buffer": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-            "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-            "dev": true
-        },
-        "is-builtin-module": {
+        "is-absolute": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
-        },
-        "is-dotfile": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-            "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
-            }
-        },
-        "is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -1572,44 +763,20 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
-        "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "1.0.1"
-            }
-        },
         "is-glob": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
-        "is-my-json-valid": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-            "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-            }
-        },
-        "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true,
-            "requires": {
-                "kind-of": "3.1.0"
-            }
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
         },
         "is-obj": {
             "version": "1.0.1",
@@ -1617,29 +784,14 @@
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -1647,16 +799,25 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
-        "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "isarray": {
@@ -1665,66 +826,44 @@
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
-        "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            }
-        },
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
-        "jade": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "requires": {
-                "commander": "0.6.1",
-                "mkdirp": "0.3.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
         },
-        "jodid25519": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+        "js-yaml": {
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+            "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
             "dev": true,
-            "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stable-stringify": {
@@ -1733,7 +872,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1748,12 +887,6 @@
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
             "dev": true
         },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
         "jsprim": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
@@ -1765,308 +898,23 @@
                 "verror": "1.3.6"
             }
         },
-        "kind-of": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-            "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-            "dev": true,
-            "requires": {
-                "is-buffer": "1.1.4"
-            }
-        },
         "lazystream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.2.3"
+                "readable-stream": "^2.0.5"
             }
         },
-        "load-json-file": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "flush-write-stream": "^1.0.2"
             }
-        },
-        "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-            "dev": true
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._escapehtmlchar": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-            "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-            "dev": true,
-            "requires": {
-                "lodash._htmlescapes": "2.4.1"
-            }
-        },
-        "lodash._escapestringchar": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-            "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._htmlescapes": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-            "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._isnative": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-            "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
-            "dev": true
-        },
-        "lodash._objecttypes": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-            "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._reunescapedhtml": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-            "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-            "dev": true,
-            "requires": {
-                "lodash._htmlescapes": "2.4.1",
-                "lodash.keys": "2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
-                    }
-                }
-            }
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash._shimkeys": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-            "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "2.4.1"
-            }
-        },
-        "lodash.defaults": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-            "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "2.4.1",
-                "lodash.keys": "2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
-                    }
-                }
-            }
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
-        },
-        "lodash.isobject": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-            "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "2.4.1"
-            }
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
-        },
-        "lodash.values": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-            "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-            "dev": true,
-            "requires": {
-                "lodash.keys": "2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
-                    }
-                }
-            }
-        },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
-            }
-        },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
         },
         "map-stream": {
             "version": "0.1.0",
@@ -2074,100 +922,19 @@
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.3.5",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
-                }
-            }
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.2.3"
-            }
-        },
-        "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
-            "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.0",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.1.0",
-                "normalize-path": "2.0.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
-            }
-        },
         "mime-db": {
-            "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-            "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-            "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+            "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "dev": true,
             "requires": {
-                "mime-db": "1.12.0"
-            },
-            "dependencies": {
-                "mime-db": {
-                    "version": "1.12.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                    "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-                    "dev": true
-                }
+                "mime-db": "~1.38.0"
             }
         },
         "minimatch": {
@@ -2176,14 +943,8 @@
             "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
             }
-        },
-        "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-            "dev": true
         },
         "mkdirp": {
             "version": "0.5.1",
@@ -2202,162 +963,61 @@
                 }
             }
         },
-        "mocha": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-            "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
-            "dev": true,
-            "requires": {
-                "commander": "2.3.0",
-                "debug": "2.2.0",
-                "diff": "1.4.0",
-                "escape-string-regexp": "1.0.2",
-                "glob": "3.2.11",
-                "growl": "1.9.2",
-                "jade": "0.26.3",
-                "mkdirp": "0.5.1",
-                "supports-color": "1.2.0",
-                "to-iso-string": "0.0.2"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-                    "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-                    "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-                    "dev": true
-                },
-                "glob": {
-                    "version": "3.2.11",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3",
-                        "minimatch": "0.3.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-                    "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-                    "dev": true
-                }
-            }
-        },
-        "ms": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-            "dev": true
-        },
         "multimatch": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.3"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
-        },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.0.2"
-            }
-        },
-        "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
-            "dev": true
-        },
-        "node-uuid": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-            "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
-            "dev": true
         },
         "node.extend": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "is": "3.2.0"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
-        "normalize-package-data": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-            "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.2.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
+                "once": "^1.3.2"
             }
-        },
-        "normalize-path": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-            "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
-            "dev": true
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
-        "object-assign": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-            "dev": true
-        },
-        "object-keys": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-            "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-            "dev": true
-        },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "for-own": "0.1.4",
-                "is-extendable": "0.1.1"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            },
+            "dependencies": {
+                "object-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+                    "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+                    "dev": true
+                }
             }
         },
         "once": {
@@ -2366,55 +1026,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
-            }
-        },
-        "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-            "dev": true,
-            "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.2.3"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.2",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
-            }
-        },
-        "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
-            "requires": {
-                "error-ex": "1.3.0"
+                "wrappy": "1"
             }
         },
         "path-dirname": {
@@ -2423,31 +1035,17 @@
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
-        "path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
-            "requires": {
-                "pinkie-promise": "2.0.1"
-            }
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
-        "path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            }
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
         },
         "pause-stream": {
             "version": "0.0.11",
@@ -2455,7 +1053,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -2464,38 +1062,109 @@
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
             "dev": true
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                    "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+                    "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^1.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                    "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+                    "dev": true
+                }
             }
-        },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
         },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
             "dev": true
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+            "dev": true
+        },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            },
+            "dependencies": {
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
+                    }
+                }
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            },
+            "dependencies": {
+                "duplexify": {
+                    "version": "3.7.1",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+                    "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
+                    }
+                }
+            }
         },
         "punycode": {
             "version": "1.4.1",
@@ -2504,50 +1173,16 @@
             "dev": true
         },
         "qs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-            "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw=",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
-        "queue": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
-            "dev": true,
-            "requires": {
-                "inherits": "2.0.3"
-            }
-        },
-        "randomatic": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-            "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-            "dev": true,
-            "requires": {
-                "is-number": "2.1.0",
-                "kind-of": "3.1.0"
-            }
-        },
-        "read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
-            "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.3.5",
-                "path-type": "1.1.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
-            "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-            }
+        "querystringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+            "dev": true
         },
         "readable-stream": {
             "version": "2.2.3",
@@ -2555,55 +1190,49 @@
             "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
             "dev": true,
             "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "buffer-shims": "^1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
             }
         },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                    "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+                    "dev": true
+                }
             }
         },
-        "regex-cache": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
-        "repeat-element": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "1.0.2"
-            }
         },
         "replace-ext": {
             "version": "0.0.1",
@@ -2612,124 +1241,55 @@
             "dev": true
         },
         "request": {
-            "version": "2.79.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-            "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.0",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.2",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.14",
-                "oauth-sign": "0.8.2",
-                "qs": "6.3.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.4.3",
-                "uuid": "3.0.1"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                    "dev": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                    "dev": true
-                },
-                "caseless": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                    "dev": true
-                },
-                "extend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                    "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-                    "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-                    "dev": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.14"
-                    }
-                },
-                "har-validator": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.9.0",
-                        "is-my-json-valid": "2.15.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "hawk": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                    "dev": true,
-                    "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.3.1",
-                        "sshpk": "1.10.2"
-                    }
-                },
-                "mime-types": {
-                    "version": "2.1.14",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-                    "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.26.0"
-                    }
-                },
-                "qs": {
-                    "version": "6.3.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
-                    "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-                    "dev": true
-                }
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
             }
         },
         "rimraf": {
@@ -2738,7 +1298,7 @@
             "integrity": "sha1-ibig/kMrn/nsmpJaALbNs6kbuto=",
             "dev": true,
             "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
             },
             "dependencies": {
                 "glob": {
@@ -2747,15 +1307,27 @@
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "semver": {
             "version": "5.3.0",
@@ -2763,110 +1335,27 @@
             "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
             "dev": true
         },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-            "dev": true
-        },
-        "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true,
-            "requires": {
-                "hoek": "2.16.3"
-            }
-        },
-        "source-map": {
-            "version": "0.1.32",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-            "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-            "dev": true,
-            "requires": {
-                "amdefine": "1.0.1"
-            }
-        },
-        "source-map-support": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
-            "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
-            "dev": true,
-            "requires": {
-                "source-map": "0.1.32"
-            }
-        },
-        "sparkles": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-            "dev": true
-        },
-        "spdx-correct": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-            "dev": true,
-            "requires": {
-                "spdx-license-ids": "1.2.2"
-            }
-        },
-        "spdx-expression-parse": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-            "dev": true
-        },
-        "spdx-license-ids": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-            "dev": true
-        },
-        "split": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-            "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-            "dev": true,
-            "requires": {
-                "through": "2.3.8"
-            }
         },
         "sshpk": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-            "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.6",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-            },
-            "dependencies": {
-                "asn1": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                    "dev": true
-                },
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -2881,7 +1370,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2896,7 +1385,7 @@
             "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.2.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2911,47 +1400,13 @@
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
             "dev": true
         },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-            "dev": true
-        },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
-            }
-        },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "0.2.1"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
-            }
-        },
-        "strip-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "4.0.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "supports-color": {
@@ -2959,17 +1414,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
-        },
-        "tar": {
-            "version": "0.1.20",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
-            "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
-            "dev": true,
-            "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "0.1.31",
-                "inherits": "2.0.3"
-            }
         },
         "through": {
             "version": "2.3.8",
@@ -2983,8 +1427,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.2.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2993,63 +1437,172 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
-        "time-stamp": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
-            "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
-            "dev": true
-        },
-        "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "through2": "^2.0.3"
             }
-        },
-        "to-iso-string": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
         },
         "tough-cookie": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             }
         },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
             "dev": true
         },
+        "tslint": {
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+            "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+                    "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
         "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-            "dev": true
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "typescript": {
-            "version": "1.8.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
-            "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
+            "version": "3.3.3333",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+            "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+            "dev": true
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
             "dev": true
         },
         "unique-stream": {
@@ -3058,8 +1611,35 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -3068,21 +1648,17 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
-        "validate-npm-package-license": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
-            }
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.3.6",
@@ -3093,69 +1669,14 @@
                 "extsprintf": "1.0.2"
             }
         },
-        "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true,
-            "requires": {
-                "clone": "1.0.2",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
-            }
-        },
-        "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-            "dev": true,
-            "requires": {
-                "duplexify": "3.5.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.2.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.2",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
         "vinyl-source-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
             "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -3176,10 +1697,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "through2": {
@@ -3188,8 +1709,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -3198,31 +1719,873 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
+                    }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+                    "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
         },
         "vscode": {
-            "version": "0.11.18",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-0.11.18.tgz",
-            "integrity": "sha1-BK2rgSenw/ezRY0cqWSFH9+gB2g=",
+            "version": "1.1.30",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.30.tgz",
+            "integrity": "sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==",
             "dev": true,
             "requires": {
-                "glob": "5.0.15",
-                "gulp-chmod": "1.3.0",
-                "gulp-filter": "4.0.0",
-                "gulp-gunzip": "0.0.3",
-                "gulp-remote-src": "0.4.1",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.4",
-                "gulp-vinyl-zip": "1.4.0",
-                "mocha": "2.5.3",
-                "request": "2.79.0",
-                "semver": "5.3.0",
-                "source-map-support": "0.3.3",
-                "vinyl-source-stream": "1.1.0"
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
+                "gulp-gunzip": "1.0.0",
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.2",
+                "mocha": "^4.0.1",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
+                "vinyl-source-stream": "^1.1.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "clone": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+                    "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "diff": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+                    "dev": true
+                },
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.1",
+                        "from": "^0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "^0.0.11",
+                        "split": "^1.0.1",
+                        "stream-combiner": "^0.2.2",
+                        "through": "^2.3.8"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "from": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+                    "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "glob-stream": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+                    "dev": true,
+                    "requires": {
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "growl": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+                    "dev": true
+                },
+                "gulp-chmod": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+                    "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+                    "dev": true,
+                    "requires": {
+                        "deep-assign": "^1.0.0",
+                        "stat-mode": "^0.2.0",
+                        "through2": "^2.0.0"
+                    }
+                },
+                "gulp-filter": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+                    "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
+                    "dev": true,
+                    "requires": {
+                        "multimatch": "^2.0.0",
+                        "plugin-error": "^0.1.2",
+                        "streamfilter": "^1.0.5"
+                    }
+                },
+                "gulp-gunzip": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
+                    "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "~0.6.5",
+                        "vinyl": "~0.4.6"
+                    },
+                    "dependencies": {
+                        "through2": {
+                            "version": "0.6.5",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
+                            }
+                        }
+                    }
+                },
+                "gulp-untar": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
+                    "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "~3.3.4",
+                        "streamifier": "~0.1.1",
+                        "tar": "^2.2.1",
+                        "through2": "~2.0.3",
+                        "vinyl": "^1.2.0"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                            "dev": true
+                        },
+                        "vinyl": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                            "dev": true,
+                            "requires": {
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
+                                "replace-ext": "0.0.1"
+                            }
+                        }
+                    }
+                },
+                "gulp-vinyl-zip": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
+                    "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
+                    "dev": true,
+                    "requires": {
+                        "event-stream": "3.3.4",
+                        "queue": "^4.2.1",
+                        "through2": "^2.0.3",
+                        "vinyl": "^2.0.2",
+                        "vinyl-fs": "^3.0.3",
+                        "yauzl": "^2.2.1",
+                        "yazl": "^2.2.1"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                            "dev": true
+                        },
+                        "clone-stats": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                            "dev": true
+                        },
+                        "event-stream": {
+                            "version": "3.3.4",
+                            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+                            "dev": true,
+                            "requires": {
+                                "duplexer": "~0.1.1",
+                                "from": "~0",
+                                "map-stream": "~0.1.0",
+                                "pause-stream": "0.0.11",
+                                "split": "0.3",
+                                "stream-combiner": "~0.0.4",
+                                "through": "~2.3.1"
+                            }
+                        },
+                        "map-stream": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+                            "dev": true
+                        },
+                        "replace-ext": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                            "dev": true
+                        },
+                        "split": {
+                            "version": "0.3.3",
+                            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+                            "dev": true,
+                            "requires": {
+                                "through": "2"
+                            }
+                        },
+                        "stream-combiner": {
+                            "version": "0.0.4",
+                            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+                            "dev": true,
+                            "requires": {
+                                "duplexer": "~0.1.1"
+                            }
+                        },
+                        "vinyl": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                            "dev": true,
+                            "requires": {
+                                "clone": "^2.1.1",
+                                "clone-buffer": "^1.0.0",
+                                "clone-stats": "^1.0.0",
+                                "cloneable-readable": "^1.0.0",
+                                "remove-trailing-separator": "^1.0.1",
+                                "replace-ext": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "har-validator": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+                    "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.5.5",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "is-valid-glob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "map-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+                    "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+                    "dev": true
+                },
+                "mime-db": {
+                    "version": "1.38.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+                    "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.22",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+                    "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.38.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "mocha": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+                    "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+                    "dev": true,
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.11.0",
+                        "debug": "3.1.0",
+                        "diff": "3.3.1",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.3",
+                        "he": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "4.4.0"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.2",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+                    "dev": true
+                },
+                "ordered-read-streams": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "queue": {
+                    "version": "4.5.1",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+                    "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "~2.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.11",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+                    "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "split": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+                    "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+                    "dev": true,
+                    "requires": {
+                        "through": "2"
+                    }
+                },
+                "stream-combiner": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+                    "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "~0.1.1",
+                        "through": "~2.3.4"
+                    }
+                },
+                "supports-color": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^2.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
+                    }
+                },
+                "to-absolute-glob": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+                    "dev": true,
+                    "requires": {
+                        "is-absolute": "^1.0.0",
+                        "is-negated-glob": "^1.0.0"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.4.6",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
+                    }
+                },
+                "vinyl-fs": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+                    "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+                    "dev": true,
+                    "requires": {
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "clone": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                            "dev": true
+                        },
+                        "clone-stats": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                            "dev": true
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "replace-ext": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                            "dev": true
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "vinyl": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                            "dev": true,
+                            "requires": {
+                                "clone": "^2.1.1",
+                                "clone-buffer": "^1.0.0",
+                                "clone-stats": "^1.0.0",
+                                "cloneable-readable": "^1.0.0",
+                                "remove-trailing-separator": "^1.0.1",
+                                "replace-ext": "^1.0.0"
+                            }
+                        }
+                    }
+                }
             }
         },
         "wrappy": {
@@ -3243,8 +2606,8 @@
             "integrity": "sha1-4h2EeGi0lvwp6uwj7of90z6bK84=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -3253,7 +2616,7 @@
             "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/stevensona/shader-toy/issues"
     },
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.32.0"
     },
     "categories": [
         "Other"
@@ -20,7 +20,7 @@
     "activationEvents": [
         "onCommand:shader-toy.showGlslPreview"
     ],
-    "main": "./out/src/extension",
+    "main": "./out/src/extension.js",
     "contributes": {
         "configuration": {
             "properties": {
@@ -106,13 +106,18 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
+        "typescript": "^3.3.1",
+        "vscode": "^1.1.28",
+        "tslint": "^5.12.1",
+        "@types/node": "^10.12.21",
+        "@types/mocha": "^2.2.42"
     },
     "icon": "resources/thumb.png"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,21 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "outDir": "out",
-        "noLib": true,
-        "sourceMap": true,
-        "rootDir": "."
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"lib": [
+			"es6"
+		],
+		"sourceMap": true,
+		"rootDir": ".",
+		"strict": true   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	},
+	"exclude": [
+		"node_modules",
+		".vscode-test"
+	]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,15 @@
+{
+	"rules": {
+		"no-string-throw": true,
+		"no-unused-expression": true,
+		"no-duplicate-variable": true,
+		"curly": true,
+		"class-name": true,
+		"semicolon": [
+			true,
+			"always"
+		],
+		"triple-equals": true
+	},
+	"defaultSeverity": "warning"
+}

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
Closes #41 

This updates the required version of vscode in order to allow us to use the webview API. We want that because the next minor release will remove the previewHtml command.

I'm unsure about the packages that are used. I ran `npm install` and `npm audit fix` several times, running into dozens of weird issues until it eventually worked and at this point I'm not sure if that's because the _package.json_ file is good now or if I used _npm_ wrong previously. So checking that would be much appreciated.

This also introduces a _tslint.json_, the ideal options of which I am unsure of as well. But I could fix many potential issues thanks to this.

Lastly to be able to use the webview API a good amount of refactoring was needed. Nothing functional has changed.