### PR TITLE
Two bug fixes, path issues and empty editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Contributions of any kind are welcome and encouraged.
 
 ## Release Notes
 
+### 0.8.1
+* Fixed issue with path generation on Linux and MacOS resulting in a broken experience,
+* fixed issue where editor changes would trigger a shader reload even if they were not text editors.
+
+### 0.8.0
+* Refactored a lot of code to use Visual Studio Code's _WebView API_ instead of its deprecated _PreviewHtml_ command.
+
 ### 0.7.10
 * Fixed behaviour of iMouse to resemble shaderoty.com as close as possible,
 * added iMouseButton uniform which holds left mousebutton in x and right mousebutton in y, 0 being up and 1 being down.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "shader-toy",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shader-toy",
     "displayName": "Shader Toy",
     "description": "Live preview of GLSL shaders similar to shadertoy",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "publisher": "stevensona",
     "license": "MIT",
     "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
     if (config.get<boolean>('reloadOnChangeEditor')) {
         vscode.window.onDidChangeActiveTextEditor((swappedEditor: vscode.TextEditor | undefined) => {
-            if (swappedEditor !== undefined) {
+            if (swappedEditor !== undefined && swappedEditor.document.lineCount > 0) {
                 activeEditor = swappedEditor;
                 updateWebview();
             }


### PR DESCRIPTION
Presumably closes #45 
I would really appreciate a test on MacOS since I have no chance of doing that. The root issue looks like it could very well be related to this on MacOS as well though, so I'm optimistic.

The other bug seems to have appeared for me on a newer version of VS Code, not sure if that's a bug in VS Code or if we didn't take care of that before. Either way we are taking care of it now.