### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Contributions of any kind are welcome and encouraged.
 
 ## Release Notes
 
+### 0.8.5
+* Hotfix for missing dependencies.
+
 ### 0.8.4
 * The extension now reloads the GLSL Preview when the user changes the extension's settings,
 * iTime, iMouse and iKeyboard states now persist across compilations of the same shader,

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,8 +209,7 @@
         "compare-versions": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-            "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
-            "dev": true
+            "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -524,8 +523,7 @@
         "mime": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-            "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
-            "dev": true
+            "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
         },
         "mime-db": {
             "version": "1.40.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,10 @@
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
+    "dependencies": {
+        "mime": "^2.4.2",
+        "compare-versions": "^3.4.0"
+    },
     "devDependencies": {
         "@types/mocha": "^2.2.42",
         "@types/node": "^10.12.21",
@@ -139,9 +143,7 @@
         "@types/mime": "^2.0.0",
         "tslint": "^5.12.1",
         "typescript": "^3.3.1",
-        "vscode": "^1.1.33",
-        "mime": "^2.4.2",
-        "compare-versions": "^3.4.0"
+        "vscode": "^1.1.33"
     },
     "icon": "resources/thumb.png"
 }


### PR DESCRIPTION
Fixes #51 

Am I right in assuming that only the _js_ dependencies are required and not the types? My thinking here is that the extension appear to be compiled from _ts_ down to _js_ and thus the types are not needed.

To (hopefully) verify that the only thing needed are these two I ran `npm install mime` and `npm install compare-versions` inside my installed extension. Is this sufficient or is there something else to check?