### PR TITLE
Errors as diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ void main() {
   gl_FragColor = vec4(r, g, b, 1.0);
 }
 ```
-Note that compared to *shadertoy.com* `gl_FragCoord` replaces `fragCoord` and `gl_FragColor` replaces `fragColor` in the original demo. There is however a rudimentary support for inserting a trivial `void main()` which will delegate to a `void mainImage(out vec4, in vec2)` function.
+Note that compared to *shadertoy.com* `gl_FragCoord` replaces `fragCoord` and `gl_FragColor` replaces `fragColor` in the original demo. There is however a rudimentary support for inserting a trivial `void main()` which will delegate to a `void mainImage(out vec4, in vec2)` function. The definition of `void main()` is found by matching the regex `/void\s+main\s*\(\s*\)\s*\{/g`, thus if you require to define `void main()` in addition to the extension generating a definition you may define it as `void main(void)`. This might be necessary, for example, if your main definition would be processed away by the preprocessor and should thus not be picked up by the extension. 
 
 ### GLSL Preview Interaction
 The extension provides a pause button inside the GLSL Preview to stop the progression of time. In conjunction with this you can use the screenshot button provided inside the GLSL Preview to capture and save a frame. Lastly the extension provides a superficial view into the shaders performance and memory consumption.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Contributions of any kind are welcome and encouraged.
 
 ## Release Notes
 
+### 0.8.6
+* Document how main definition is found,
+* remove version directives from shaders,
+* fix an issue that would remove all newlines from beginning of shader and cause errors to be reported on the wrong lines,
+* reintroduce error when textures could not be loaded,
+* add iGlobalFrame,
+* add option that shows compile errors as diagnostics, enabled by default.
+
 ### 0.8.5
 * Hotfix for missing dependencies.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
                     ],
                     "description": "Force the rendering into a specific aspect ratio. Set either to zero or negative to ignore."
                 },
+                "shader-toy.showCompileErrorsAsDiagnostics": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show all compile errors directly in the editor as diagnostics."
+                },
                 "shader-toy.omitDeprecationWarnings": {
                     "type": "boolean",
                     "default": false,

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,7 +45,8 @@ export class Context {
             if (currentFile === diagnosticBatch.filename) {
                 let collectedDiagnostics: vscode.Diagnostic[] = [];
                 for (let diagnostic of diagnosticBatch.diagnostics) {
-                    let range = this.activeEditor.document.lineAt(diagnostic.line - 1).range;
+                    let line = Math.max(1, diagnostic.line) - 1;
+                    let range = this.activeEditor.document.lineAt(line).range;
                     collectedDiagnostics.push(new vscode.Diagnostic(range, diagnostic.message, severity));
                 }
                 this.diagnosticCollection.set(this.activeEditor.document.uri, collectedDiagnostics);

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,7 +7,9 @@ import { DiagnosticBatch } from './typenames';
 export class Context {
     private context: vscode.ExtensionContext;
     private config: vscode.WorkspaceConfiguration;
+
     private diagnosticCollection: vscode.DiagnosticCollection;
+    private collectedDiagnostics: vscode.Diagnostic[] = [];
     
     public activeEditor: vscode.TextEditor | undefined;
     
@@ -36,6 +38,7 @@ export class Context {
     }
 
     public clearDiagnostics() {
+        this.collectedDiagnostics = [];
         this.diagnosticCollection.clear();
     }
     public showDiagnostics(diagnosticBatch: DiagnosticBatch, severity: vscode.DiagnosticSeverity) {
@@ -43,13 +46,12 @@ export class Context {
             let currentFile = this.activeEditor.document.fileName;
             currentFile = currentFile.replace(/\\/g, '/');
             if (currentFile === diagnosticBatch.filename) {
-                let collectedDiagnostics: vscode.Diagnostic[] = [];
                 for (let diagnostic of diagnosticBatch.diagnostics) {
                     let line = Math.max(1, diagnostic.line) - 1;
                     let range = this.activeEditor.document.lineAt(line).range;
-                    collectedDiagnostics.push(new vscode.Diagnostic(range, diagnostic.message, severity));
+                    this.collectedDiagnostics.push(new vscode.Diagnostic(range, diagnostic.message, severity));
                 }
-                this.diagnosticCollection.set(this.activeEditor.document.uri, collectedDiagnostics);
+                this.diagnosticCollection.set(this.activeEditor.document.uri, this.collectedDiagnostics);
                 return;
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,6 +183,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
                             break;
                         case 'warning':
                             severity = vscode.DiagnosticSeverity.Warning;
+                            break;
                         case 'hint':
                             severity = vscode.DiagnosticSeverity.Hint;
                             break;

--- a/src/shaderparser.ts
+++ b/src/shaderparser.ts
@@ -299,6 +299,24 @@ export class ShaderParser {
             }
         }
 
+        {
+            let versionPos = code.search(/#version\s+\d+(\s+\w+|\n)/g);
+            if (versionPos >= 0) {
+                let newLinePos = code.search('\n');
+                let versionDirective = code.substring(versionPos, newLinePos);
+                code = code.replace(versionDirective, "");
+
+                let diagnosticBatch: types.DiagnosticBatch = {
+                    filename: name,
+                    diagnostics: [{
+                        line: 1,
+                        message: "Version directive ignored by shader-toy extension"
+                    }]
+                };
+                this.context.showDiagnostics(diagnosticBatch, vscode.DiagnosticSeverity.Information);
+            }
+        }
+
         // If there is no void main() in the shader we assume it is a shader-toy style shader
         let mainPos = code.search(/void\s+main\s*\(\s*\)\s*\{/g);
         let mainImagePos = code.search(/void\s+mainImage\s*\(\s*out\s+vec4\s+\w+,\s*(in\s)?\s*vec2\s+\w+\s*\)\s*\{/g);

--- a/src/shaderparser.ts
+++ b/src/shaderparser.ts
@@ -9,9 +9,11 @@ import { Context } from './context';
 
 export class ShaderParser {
     private context: Context;
+    private lineOffset: number;
     
-    constructor(context: Context) {
+    constructor(context: Context, lineOffset: number) {
         this.context = context;
+        this.lineOffset = lineOffset;
     }
 
     private readShaderFile(file: string): { success: boolean, error: any, bufferCode: string } {
@@ -50,7 +52,7 @@ export class ShaderParser {
             return;
         }
 
-        let line_offset = 129;
+        let line_offset = this.lineOffset;
         let textures: types.TextureDefinition[] = [];
         let audios: types.AudioDefinition[] = [];
         let includeName: string | undefined;

--- a/src/shaderparser.ts
+++ b/src/shaderparser.ts
@@ -50,7 +50,7 @@ export class ShaderParser {
             return;
         }
 
-        let line_offset = 127;
+        let line_offset = 129;
         let textures: types.TextureDefinition[] = [];
         let audios: types.AudioDefinition[] = [];
         let includeName: string | undefined;

--- a/src/typenames.ts
+++ b/src/typenames.ts
@@ -56,3 +56,12 @@ export type IncludeDefinition = {
     Code: string,
     LineCount: number
 };
+
+export type Diagnostic = {
+    line: number,
+    message: string
+};
+export type DiagnosticBatch = {
+    filename: string,
+    diagnostics: Diagnostic[]
+};

--- a/src/webviewcontentprovider.ts
+++ b/src/webviewcontentprovider.ts
@@ -22,7 +22,6 @@ export class WebviewContentProvider {
 
         let shaderPreamble = `
         uniform vec3        iResolution;
-        uniform float       iGlobalTime;
         uniform float       iTime;
         uniform float       iTimeDelta;
         uniform int         iFrame;
@@ -43,6 +42,9 @@ export class WebviewContentProvider {
         uniform sampler2D   iChannel9;
         uniform sampler2D   iKeyboard;
         uniform float       iSampleRate;
+
+        #define iGloablTime iTime
+        #define iGloablFrame iFrame
 
         #define SHADER_TOY`;
 
@@ -237,7 +239,6 @@ export class WebviewContentProvider {
                     depthTest: false,
                     uniforms: {
                         iResolution: { type: "v3", value: resolution },
-                        iGlobalTime: { type: "f", value: 0.0 },
                         iTime: { type: "f", value: 0.0 },
                         iTimeDelta: { type: "f", value: 0.0 },
                         iFrame: { type: "i", value: 0 },
@@ -869,7 +870,6 @@ export class WebviewContentProvider {
                     for (let buffer of buffers) {
                         buffer.Shader.uniforms['iResolution'].value = resolution;
                         buffer.Shader.uniforms['iTimeDelta'].value = deltaTime;
-                        buffer.Shader.uniforms['iGlobalTime'].value = time;
                         buffer.Shader.uniforms['iTime'].value = time;
                         buffer.Shader.uniforms['iFrame'].value = frameCounter;
                         buffer.Shader.uniforms['iMouse'].value = mouse;

--- a/src/webviewcontentprovider.ts
+++ b/src/webviewcontentprovider.ts
@@ -278,6 +278,12 @@ export class WebviewContentProvider {
             texture.wrapS = THREE.RepeatWrapping;
             texture.wrapT = THREE.RepeatWrapping;
         }`;
+        let makeTextureLoadErrorScript = (filename: string) => `function(err) {
+            vscode.postMessage({
+                command: 'errorMessage',
+                message: "Failed loading texture file ${filename}"
+            });
+        }`;
 
         let audioScripts = {
             Init: "",
@@ -302,10 +308,11 @@ export class WebviewContentProvider {
                 }
                 else if (localPath !== undefined) {
                     const resolvedPath = this.context.makeWebviewResource(this.context.makeUri(localPath));
-                    value = `texLoader.load('${resolvedPath.toString()}', ${textureLoadScript})`;
+                    const resolvedPathString = resolvedPath.toString();
+                    value = `texLoader.load('${resolvedPathString}', ${textureLoadScript}, undefined, ${makeTextureLoadErrorScript(resolvedPathString)})`;
                 }
                 else if (remotePath !== undefined) {
-                    value = `texLoader.load('https://${remotePath}', ${textureLoadScript})`;
+                    value = `texLoader.load('https://${remotePath}', ${textureLoadScript}, undefined, ${makeTextureLoadErrorScript(`https://${remotePath}`)})`;
                 }
 
                 if (value !== undefined) {

--- a/src/webviewcontentprovider.ts
+++ b/src/webviewcontentprovider.ts
@@ -47,12 +47,14 @@ export class WebviewContentProvider {
         #define iGloablFrame iFrame
 
         #define SHADER_TOY`;
+        let shaderPreambleLineNumbers = shaderPreamble.split(/\r\n|\n/).length;
+        let webglLineNumbers = 102;
 
         shaderName = shaderName.replace(/\\/g, '/');
         let buffers: types.BufferDefinition[] = [];
         let commonIncludes: types.IncludeDefinition[] = [];
 
-        new ShaderParser(this.context).parseShaderCode(shaderName, shader, buffers, commonIncludes);
+        new ShaderParser(this.context, shaderPreambleLineNumbers + webglLineNumbers).parseShaderCode(shaderName, shader, buffers, commonIncludes);
 
         // If final buffer uses feedback we need to add a last pass that renders it to the screen
         // because we can not ping-pong the screen
@@ -817,7 +819,7 @@ export class WebviewContentProvider {
                     currentShader = {
                         Name: include.Name,
                         File: include.File,
-                        LineOffset: ${shaderPreamble.split(/\r\n|\n/).length}  + 2 // add two for version and precision lines
+                        LineOffset: ${shaderPreambleLineNumbers} + 2 // add two for version and precision lines
                     };
                     // bail if there is an error found in the include script
                     if(compileFragShader(gl, document.getElementById(include.Name).textContent) == false) throw Error(\`Failed to compile \${include.Name}\`);


### PR DESCRIPTION
Adds compile errors as diagnostics, i.e. squiggly lines in the text editor. Actual compile errors are displayed on hovering. The feature is optional and can be disabled in settings. This feature does not replace the traditional way of displaying errors but complements it.

The diagnostics can be used both from the webview as well as from the extension directly. Thus we can use them in the future to replace warning/error popups where reasonable. But I didn't want to just replace everything right out.

Additionally:
closes #54 by providing an error popup when textures fail to load
closes #53 by the suggested changes in the issue