### PR TITLE
Big parsing rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ At the moment, `iResolution`, `iGlobalTime` (also as `iTime`), `iTimeDelta`, `iF
 ### Texture Input
 The texture channels `iChannelN` may be defined by inserting code of the following form at the top of your shader
 ```
-#iChannel0 "file://./duck.png"
+#iChannel0 "file://duck.png"
 #iChannel1 "https://66.media.tumblr.com/tumblr_mcmeonhR1e1ridypxo1_500.jpg"
-#iChannel2 "file://./other/shader.glsl"
+#iChannel2 "file://other/shader.glsl"
 #iChannel2 "self"
-#iChannel4 "file://./music/epic.mp3"
+#iChannel4 "file://music/epic.mp3"
 ```
 This demonstrates using local and remote images as textures *(Remember that power of 2 texture sizes is generally what you want to stick to.)*, using another shaders results as a texture, using the last frame of this shader by specifying `self` or using audio input. Note that to use relative paths for local input you will have to open a folder in Visual Code.
 ![texture example](https://raw.githubusercontent.com/stevensona/shader-toy/master/images/example2.png)
@@ -53,18 +53,18 @@ Additionally it will expose variables such as `Key_A` to `Key_Z`, `Key_0` to `Ke
 ### Shader Includes
 You may also include other files into your shader via a standard C-like syntax:
 ```
-#include "./some/shared/code.glsl"
-#include "./other/local/shader_code.glsl"
+#include "some/shared/code.glsl"
+#include "other/local/shader_code.glsl"
 ```
 These shaders may not define a `void main()` function and as such can be used only for utility functions, constant definitions etc.
 
 ### Custom Uniforms (experimental and subject to change)
 To use custom uniforms define those directly in your shader, giving an initial value as well as an optional range for the uniform.
 ```glsl
-#iUniform my_scalar = 1.0 in [0.0, 5.0] // This will expose a slider to edit the value
-#iUniform other_scalar = 5.0 // This will expose a text field to give an arbitrary value
-#iUniform my_color = vec3(1.0) // This will be editable as a color picker
-#iUniform other_color = vec4(1.0) in [0.0, 1.0] // This will expose four sliders
+#iUniform float my_scalar = 1.0 in { 0.0, 5.0 } // This will expose a slider to edit the value
+#iUniform float other_scalar = 5.0 // This will expose a text field to give an arbitrary value
+#iUniform vec3 my_color = vec3(1.0) // This will be editable as a color picker
+#iUniform vec4 other_color = vec4(1.0) in { 0.0, 1.0 } // This will expose four sliders
 ```
 
 ### Compatibility with Shadertoy.com
@@ -137,7 +137,10 @@ The extension also supports highlighting of compilation errors in the text edito
 
 ## Todo
 
-* Receive more feedback
+* Receive more feedback,
+* portable export of shader,
+* disable audio in non-portable version,
+* cubemap sampling.
 
 ## Contributing
 
@@ -148,6 +151,15 @@ Contributions of any kind are welcome and encouraged.
 [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=stevensona.shader-toy)
 
 ## Release Notes
+
+### 0.10.1
+* Correctly parse comments in GLSL code, allowing to remove e.g. texture definitions with both single- as well as multi-line comments,
+* changed syntax for uniform definitions to align closer to standard GLSL syntax,
+* allow definitions of e.g. textures to be made in include files,
+* reworked path resolution for files, adding the possibility to find files relative to the file they are used in,
+* make the initial './' in relative paths optional,
+* reload shaders when their dependents change, e.g. when included files change,
+* maintain state of uniforms gui across reloads.
 
 ### 0.9.2
 * Add controls for custom uniforms,

--- a/demos/blobby.glsl
+++ b/demos/blobby.glsl
@@ -1,4 +1,4 @@
-#include "./common/blobby-common.glsl"
+#include "common/blobby-common.glsl"
 
 float blob(vec2 pos, vec2 center, float power)
 {

--- a/demos/common/blobby-common.glsl
+++ b/demos/common/blobby-common.glsl
@@ -1,4 +1,4 @@
-#include "./common/math-common.glsl"
+#include "math-common.glsl"
 
 #define saturate01(x) (clamp(x, 0., 1.))
 

--- a/demos/multipass.glsl
+++ b/demos/multipass.glsl
@@ -1,5 +1,5 @@
-#iChannel0 "file://./horizon.jpg"
-#iChannel1 "file://./uv-warp.glsl"
+#iChannel0 "file://horizon.jpg"
+#iChannel1 "file://uv-warp.glsl"
 
 void main() {
     vec2 uv = gl_FragCoord.xy / iResolution.xy;

--- a/demos/volume_points_0.glsl
+++ b/demos/volume_points_0.glsl
@@ -1,4 +1,4 @@
-#include "./volume_points_common.glsl"
+#include "volume_points_common.glsl"
 
 vec3 iVResolution = vec3(0);
 

--- a/demos/volume_points_1.glsl
+++ b/demos/volume_points_1.glsl
@@ -1,9 +1,9 @@
 // Shader by Flyguy
 // Adapted for shadertoy VS-Code from: https://www.shadertoy.com/view/MtdcDn
 
-#iChannel0 "./volume_points_0.glsl"
+#iChannel0 "volume_points_0.glsl"
 
-#include "./volume_points_common.glsl"
+#include "volume_points_common.glsl"
 
 #define DEBUG 0 //Visualize the planes
 #define ADD 1
@@ -11,11 +11,11 @@
 
 #define BLENDMODE ADD
 
-#iUniform CUBE_SIZE = 1.5 in [ 0.5, 3.5 ]
-#iUniform GRID_RES = 17.0 in [ 8, 32 ]
-#iUniform POINT_SIZE = 0.375 in [ 0.01, 1.5 ]
-#iUniform COLOR_BOOST = vec3(1, 1, 1)
-#iUniform ALPHA_BOOST = 3.0 in [ 0, 3 ]
+#iUniform float CUBE_SIZE = 1.5 in { 0.5, 3.5 }
+#iUniform float GRID_RES = 17.0 in { 8, 32 }
+#iUniform float POINT_SIZE = 0.375 in { 0.01, 1.5 }
+#iUniform vec3 COLOR_BOOST = vec3(1, 1, 1)
+#iUniform float ALPHA_BOOST = 3.0 in { 0, 3 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {

--- a/src/bufferprovider.ts
+++ b/src/bufferprovider.ts
@@ -1,0 +1,525 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as mime from 'mime';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as Types from'./typenames';
+import { Context } from './context';
+import { ShaderParser, ObjectType } from './shaderparser';
+import { URL } from 'url';
+
+type ChannelId = number;
+type InputTexture = {
+    Channel: ChannelId,
+    Local: boolean,
+    UserPath: string,
+    Path: string
+};
+type InputTextureSettings = {
+    Mag?: Types.TextureMagFilter,
+    MagLine?: number,
+    Min?: Types.TextureMinFilter,
+    MinLine?: number,
+    Wrap?: Types.TextureWrapMode
+    WrapLine?: number,
+};
+
+export class BufferProvider {
+    private context: Context;
+    private visitedFiles: string[];
+    constructor(context: Context) {
+        this.context = context;
+        this.visitedFiles = [];
+    }
+
+    public parseShaderCode(file: string, code: string, buffers: Types.BufferDefinition[], commonIncludes: Types.IncludeDefinition[]) {
+        this.parseShaderCodeInternal(file, code, buffers, commonIncludes);
+
+        const findByName = (bufferName: string) => {
+            let strippedName = this.stripPath(bufferName);
+            return (value: any) => {
+                if (value.Name === strippedName) {
+                    return true;
+                }
+                return false;
+            };
+        };
+
+        // Translate buffer names to indices including self reads
+        for (let i = 0; i < buffers.length; i++) {
+            let buffer = buffers[i];
+            let usesSelf = false;
+            let selfChannel = 0;
+            for (let j = 0; j < buffer.TextureInputs.length; j++) {
+                let texture = buffer.TextureInputs[j];
+                if (texture.Buffer) {
+                    texture.BufferIndex = buffers.findIndex(findByName(texture.Buffer));
+                }
+                else if (texture.Self) {
+                    texture.Buffer = buffer.Name;
+                    texture.BufferIndex = i;
+                    usesSelf = true;
+                    selfChannel = j;
+                }
+            }
+
+            buffer.UsesSelf = usesSelf;
+            buffer.SelfChannel = selfChannel;
+        }
+
+        // Resolve dependencies between passes
+        for (let i = 0; i < buffers.length; i++) {
+            let buffer = buffers[i];
+            for (let texture of buffer.TextureInputs) {
+                if (!texture.Self && texture.Buffer !== undefined && texture.BufferIndex !== undefined) {
+                    let dependencyBuffer = buffers[texture.BufferIndex];
+                    if (dependencyBuffer.UsesSelf) {
+                        dependencyBuffer.Dependents.push({
+                            Index: i,
+                            Channel: texture.Channel
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private readShaderFile(file: string): { success: boolean, error: any, bufferCode: string } {
+        for (let editor of vscode.window.visibleTextEditors) {
+            let editorFile = editor.document.fileName;
+            editorFile = editorFile.replace(/\\/g, '/');
+            if (editorFile === file) {
+                return { success: true, error: null, bufferCode: editor.document.getText() };
+            }
+        }
+
+        // Read the whole file of the shader
+        let success = false;
+        let bufferCode = '';
+        let error = null;
+        try {
+            bufferCode = fs.readFileSync(file, 'utf-8');
+            success = true;
+        }
+        catch (e) {
+            error = e;
+        }
+
+        return { success, error, bufferCode };
+    }
+    private stripPath(name: string): string{
+        let lastSlash = name.lastIndexOf('/');
+        return name.substring(lastSlash + 1);
+    }
+
+    private parseShaderCodeInternal(file: string, code: string, buffers: Types.BufferDefinition[], commonIncludes: Types.IncludeDefinition[]) {
+        const found = this.visitedFiles.find((visitedFile: string) => visitedFile === file);
+        if (found) {
+            return;
+        }
+        this.visitedFiles.push(file);
+
+        let boxedLineOffset: Types.BoxedValue<number> = { Value: 0 };
+        let pendingTextures: InputTexture[] = [];
+        let pendingTextureSettings: Record<ChannelId, InputTextureSettings> = {};
+        let pendingUniforms: Types.UniformDefinition[] = [];
+        let includes: Types.IncludeDefinition[] = [];
+        let usesKeyboard = false;
+
+        code = this.transformCode(file, code, boxedLineOffset, pendingTextures, pendingTextureSettings, pendingUniforms, includes, commonIncludes, usesKeyboard);
+
+        let lineOffset = boxedLineOffset.Value;
+        let textures: Types.TextureDefinition[] = [];
+        let audios: Types.AudioDefinition[] = [];
+        let uniforms: Types.UniformDefinition[] = [];
+
+        // Resolve textures
+        for (let pendingTexture of pendingTextures) {
+            let depFile = pendingTexture.Path;
+            let userPath = pendingTexture.UserPath;
+            let channel = pendingTexture.Channel;
+            let local = pendingTexture.Local;
+
+            let fullMime = mime.getType(path.extname(depFile) || 'txt') || 'text/plain';
+            let mimeType = fullMime.split('/')[0] || 'text';
+            switch (mimeType) {
+                case 'text': {
+                    if (depFile === 'self' || depFile === file) {
+                        // Push self as feedback-buffer
+                        textures.push({
+                            Channel: channel,
+                            File: file,
+                            Self: true
+                        });
+                    }
+                    else {
+                        // Read the whole file of the shader
+                        const shaderFile = this.readShaderFile(depFile);
+                        if(shaderFile.success === false){
+                            vscode.window.showErrorMessage(`Could not open file: ${userPath}`);
+                            return;
+                        }
+    
+                        // Parse the shader
+                        this.parseShaderCodeInternal(depFile, shaderFile.bufferCode, buffers, commonIncludes);
+            
+                        // Push buffers as textures
+                        textures.push({
+                            Channel: channel,
+                            File: file,
+                            Buffer: this.stripPath(depFile),
+                        });
+                    }
+                    break;
+                }
+                case 'image': {
+                    if (local) {
+                        textures.push({
+                            Channel: channel,
+                            File: file,
+                            LocalTexture: depFile,
+                            Mag: Types.TextureMagFilter.Linear,
+                            Min: Types.TextureMinFilter.Linear,
+                            Wrap: Types.TextureWrapMode.Clamp
+                        });
+                    }
+                    else {
+                        textures.push({
+                            Channel: channel,
+                            File: file,
+                            RemoteTexture: depFile,
+                            Mag: Types.TextureMagFilter.Linear,
+                            Min: Types.TextureMinFilter.Linear,
+                            Wrap: Types.TextureWrapMode.Clamp
+                        });
+                    }
+                    break;
+                }
+                case 'audio': {
+                    if (this.context.getConfig<boolean>('enabledAudioInput')) {
+                        if (local) {
+                            audios.push({
+                                Channel: channel,
+                                LocalPath: depFile,
+                                UserPath: userPath
+                            });
+                        }
+                        else {
+                            audios.push({
+                                Channel: channel,
+                                RemotePath: depFile,
+                                UserPath: userPath
+                            });
+                        }
+                    }
+                    else {
+                        vscode.window.showWarningMessage(`You are trying to use an audio file, which is currently disabled in the settings.`);
+                    }
+                    break;
+                }
+                default: {
+                    vscode.window.showWarningMessage(`You are trying to use an unsupported file ${depFile}`);
+                }
+            }
+        }
+
+        // Assign pending texture settings
+        for (let texture of textures) {
+            if (pendingTextureSettings.hasOwnProperty(texture.Channel)) {
+                let pendingSettings = pendingTextureSettings[texture.Channel];
+                texture.Mag = pendingSettings.Mag || Types.TextureMagFilter.Linear;
+                texture.MagLine = pendingSettings.MagLine;
+                texture.Min = pendingSettings.Min || Types.TextureMinFilter.Linear;
+                texture.MinLine = pendingSettings.MinLine;
+                texture.Wrap = pendingSettings.Wrap || Types.TextureWrapMode.Clamp;
+                texture.WrapLine = pendingSettings.WrapLine;
+            }
+        }
+
+        // Transfer uniforms
+        for (let pendingUniform of pendingUniforms) {
+            let uniform = Object.create(pendingUniform);
+            uniforms.push(uniform);
+        }
+
+        {
+            let versionPos = code.search(/^#version/g);
+            if (versionPos === 0) {
+                let newLinePos = code.search('\n');
+                let versionDirective = code.substring(versionPos, newLinePos - 1);
+                code = code.replace(versionDirective, '');
+
+                this.showInformationAtLine(file, `Version directive '${versionDirective}' ignored by shader-toy extension`, 0);
+            }
+        }
+
+        {
+            // If there is no void main() in the shader we assume it is a shader-toy style shader
+            let mainPos = code.search(/void\s+main\s*\(\s*\)\s*\{/g);
+            let mainImagePos = code.search(/void\s+mainImage\s*\(\s*out\s+vec4\s+\w+,\s*(in\s)?\s*vec2\s+\w+\s*\)\s*\{/g);
+            if (mainPos === -1 && mainImagePos >= 0) {
+                code += `
+void main() {
+    mainImage(gl_FragColor, gl_FragCoord.xy);
+}`;
+            }
+        }
+
+        {
+            // Check if defined textures are used in shader
+            let definedTextures: any = {};
+            for (let texture of textures) {
+                definedTextures[texture.Channel] = true;
+            }
+            for (let audio of audios) {
+                definedTextures[audio.Channel] = true;
+            }
+            if (this.context.getConfig<boolean>('warnOnUndefinedTextures')) {
+                for (let i = 0; i < 9; i++) {
+                    if (code.search('iChannel' + i) > 0) {
+                        if (definedTextures[i] === undefined) {
+                            vscode.window.showWarningMessage(`iChannel${i} in use but there is no definition #iChannel${i} in shader`, 'Details')
+                                .then(() => {
+                                    vscode.window.showInformationMessage(`To use this channel add to your shader a line '#iChannel${i}' followed by a space and the path to your texture. Use 'file://' for local textures, 'https://' for remote textures or 'buf://' for other shaders.`);
+                                });
+                        }
+                    }
+                }
+            }
+        }
+
+        if (this.context.getConfig<boolean>('enableGlslifySupport')) {
+            // glslify the code
+            var glsl = require('glslify');
+            try {
+                code = glsl(code);
+            }
+            catch(e) {
+                vscode.window.showErrorMessage(e.message);
+            }
+        }
+
+        // Push yourself after all your dependencies
+        buffers.push({
+            Name: this.stripPath(file),
+            File: file,
+            Code: code,
+            Includes: includes,
+            TextureInputs: textures,
+            AudioInputs: audios,
+            CustomUniforms: uniforms,
+            UsesSelf: false,
+            SelfChannel: -1,
+            Dependents: [],
+            UsesKeyboard: usesKeyboard,
+            LineOffset: lineOffset
+        });
+    }
+
+    private transformCode(file: string, code: string, lineOffset: Types.BoxedValue<number>, textures: InputTexture[], textureSettings: Record<ChannelId, InputTextureSettings>, 
+                          uniforms: Types.UniformDefinition[], includes: Types.IncludeDefinition[], sharedIncludes: Types.IncludeDefinition[], usesKeyboard: boolean): string {
+        
+        let addTextureSettingIfNew = (channel: number) => {
+            if (!textureSettings.hasOwnProperty(channel)) {
+                textureSettings[channel] = {};
+            }
+        };
+
+        let parser = new ShaderParser(code);
+
+        let replaceLastObject = (source: string) => {
+            let lastRange = parser.getLastObjectRange();
+            if (lastRange !== undefined) {
+                let replacedObject = code.substring(lastRange.Begin, lastRange.End);
+                code = code.substring(0, lastRange.Begin) + source + code.substring(lastRange.End);
+                parser.reset(code, lastRange.Begin + source.length);
+            }
+        };
+        let removeLastObject = () => {
+            replaceLastObject("");
+        };
+
+        while (!parser.eof()) {
+            let nextObject = parser.next();
+            if (nextObject === undefined) {
+                break;
+            }
+
+            switch (nextObject.Type) {
+                case ObjectType.Error:
+                    this.showErrorAtLine(file, nextObject.Message, parser.line());
+                    break;
+                case ObjectType.Texture: {
+                    let userPath = nextObject.Path;
+                    let textureFile: string;
+                    let local = false;
+
+                    // Note: This is sorta cursed
+                    try {
+                        let textureUrl = new URL(userPath);
+                        if (textureUrl.protocol === 'file:') {
+                            local = true;
+                        }
+                    }
+                    catch {
+                        local = true;
+                    }
+
+                    if (local) {
+                        userPath = userPath.replace('file://', '');
+                        if (userPath === 'self') {
+                            textureFile = userPath;
+                        }
+                        else {
+                            ({ file: textureFile, userPath: userPath } = this.context.mapUserPath(userPath, file));
+                        }
+                    }
+                    else {
+                        textureFile = nextObject.Path;
+                    }
+
+                    let texture: InputTexture = {
+                        Channel: nextObject.Index,
+                        Local: local,
+                        UserPath: userPath,
+                        Path: textureFile
+                    };
+                    textures.push(texture);
+                    removeLastObject();
+                    break;
+                }
+                case ObjectType.TextureMagFilter:
+                    addTextureSettingIfNew(nextObject.Index);
+                    textureSettings[nextObject.Index].Mag = nextObject.Value;
+                    textureSettings[nextObject.Index].MagLine = parser.line();
+                    removeLastObject();
+                    break;
+                case ObjectType.TextureMinFilter:
+                    addTextureSettingIfNew(nextObject.Index);
+                    textureSettings[nextObject.Index].Min = nextObject.Value;
+                    textureSettings[nextObject.Index].MinLine = parser.line();
+                    removeLastObject();
+                    break;
+                case ObjectType.TextureWrapMode:
+                    addTextureSettingIfNew(nextObject.Index);
+                    textureSettings[nextObject.Index].Wrap = nextObject.Value;
+                    textureSettings[nextObject.Index].WrapLine = parser.line();
+                    removeLastObject();
+                    break;
+                case ObjectType.Include: {
+                    let userPath = nextObject.Path;
+                    let includeFile: string;
+                    ({ file: includeFile, userPath: userPath } = this.context.mapUserPath(userPath, file));
+                    
+                    let sharedIncludeIndex = sharedIncludes.findIndex((value: Types.IncludeDefinition) => {
+                        if (value.File === includeFile) {
+                            return true;
+                        }
+                        return false;
+                    });
+
+                    if (sharedIncludeIndex < 0) {
+                        let includeCode = this.readShaderFile(includeFile);
+                        if (includeCode.success) {
+                            let include_line_offset: Types.BoxedValue<number> = { Value: 0 };
+                            let transformedIncludeCode = this.transformCode(includeFile, includeCode.bufferCode, include_line_offset, textures, textureSettings,
+                                                                            uniforms, includes, sharedIncludes, usesKeyboard);
+                            let newInclude: Types.IncludeDefinition = {
+                                Name: path.basename(includeFile),
+                                File: includeFile,
+                                Code: transformedIncludeCode,
+                                LineCount: transformedIncludeCode.split(/\r\n|\n/).length
+                            };
+                            sharedIncludes.push(newInclude);
+                            sharedIncludeIndex = sharedIncludes.length - 1;
+                        }
+                        else {
+                            this.showErrorAtLine(file, `Failed opening include file "${includeFile}"`, parser.line());
+                        }
+                    }
+
+                    if (sharedIncludeIndex >= 0) {
+                        let include = sharedIncludes[sharedIncludeIndex];
+                        includes.push(include);
+                        lineOffset.Value += include.LineCount - 1;
+                        replaceLastObject(include.Code);
+                    }
+
+                    break;
+                }
+                case ObjectType.Uniform:
+                    if (nextObject.Default !== undefined && nextObject.Min !== undefined && nextObject.Max !== undefined) {
+                        let range = [ nextObject.Min, nextObject.Max ];
+                        for (let i of [ 0, 1 ]) {
+                            let value = range[i];
+                            if (value.length !== nextObject.Default.length) {
+                                if (value.length !== 1) {
+                                    let mismatchType = value.length < nextObject.Default.length ?
+                                        'missing values will be replaced with first value given' :
+                                        'redundant values will be removed';
+                                    let valueType = i === 0 ? 'minimum' : 'maximum';
+                                    this.showDiagnosticAtLine(file, `Type mismatch in ${valueType} value, ${mismatchType}.`, parser.line(), vscode.DiagnosticSeverity.Information);
+                                }
+
+                                for (let j of [ 0, 1, 2, 3 ]) {
+                                    if (range[i][j] === undefined) {
+                                        range[i][j] = range[i][0];
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (nextObject.Default === undefined && nextObject.Min !== undefined) {
+                        nextObject.Default = nextObject.Min;
+                        this.showDiagnosticAtLine(file, `Custom uniform specifies no default value, the minimum of its range will be used.`, parser.line(), vscode.DiagnosticSeverity.Information);
+                    }
+
+                    if (nextObject.Default === undefined) {
+                        this.showErrorAtLine(file, `Can not deduce default value for custom uniform, either define a default value or range`, parser.line());
+                    }
+                    else {
+                        let uniform: Types.UniformDefinition = {
+                            Name: nextObject.Name,
+                            Typename: nextObject.Typename,
+                            Default: nextObject.Default,
+                            Min: nextObject.Min,
+                            Max: nextObject.Max,
+                            Step: nextObject.Step
+                        };
+                        uniforms.push(uniform);
+                    }
+                    removeLastObject();
+                    break;
+                case ObjectType.Keyboard:
+                    usesKeyboard = true;
+                    removeLastObject();
+                default:
+                    break;
+            }
+        }
+
+        return code;
+    }
+    
+    private showDiagnosticAtLine(file: string, message: string, line: number, severity: vscode.DiagnosticSeverity) {
+        let diagnosticBatch: Types.DiagnosticBatch = {
+            filename: file,
+            diagnostics: [{
+                line: line,
+                message: message
+            }]
+        };
+        this.context.showDiagnostics(diagnosticBatch, severity);
+    }
+    private showErrorAtLine(file: string, message: string, line: number) {
+        this.showDiagnosticAtLine(file, message, line, vscode.DiagnosticSeverity.Error);
+    }
+    private showWarningAtLine(file: string, message: string, line: number) {
+        this.showDiagnosticAtLine(file, message, line, vscode.DiagnosticSeverity.Warning);
+    }
+    private showInformationAtLine(file: string, message: string, line: number) {
+        this.showDiagnosticAtLine(file, message, line, vscode.DiagnosticSeverity.Information);
+    }
+}

--- a/src/bufferprovider.ts
+++ b/src/bufferprovider.ts
@@ -125,14 +125,15 @@ export class BufferProvider {
         let pendingTextureSettings: Record<ChannelId, InputTextureSettings> = {};
         let pendingUniforms: Types.UniformDefinition[] = [];
         let includes: Types.IncludeDefinition[] = [];
-        let usesKeyboard = false;
+        let boxedUsesKeyboard: Types.BoxedValue<boolean> = { Value: false };
 
-        code = this.transformCode(file, code, boxedLineOffset, pendingTextures, pendingTextureSettings, pendingUniforms, includes, commonIncludes, usesKeyboard);
+        code = this.transformCode(file, code, boxedLineOffset, pendingTextures, pendingTextureSettings, pendingUniforms, includes, commonIncludes, boxedUsesKeyboard);
 
         let lineOffset = boxedLineOffset.Value;
         let textures: Types.TextureDefinition[] = [];
         let audios: Types.AudioDefinition[] = [];
         let uniforms: Types.UniformDefinition[] = [];
+        let usesKeyboard = boxedUsesKeyboard.Value;
 
         // Resolve textures
         for (let pendingTexture of pendingTextures) {
@@ -318,7 +319,7 @@ void main() {
     }
 
     private transformCode(file: string, code: string, lineOffset: Types.BoxedValue<number>, textures: InputTexture[], textureSettings: Record<ChannelId, InputTextureSettings>, 
-                          uniforms: Types.UniformDefinition[], includes: Types.IncludeDefinition[], sharedIncludes: Types.IncludeDefinition[], usesKeyboard: boolean): string {
+                          uniforms: Types.UniformDefinition[], includes: Types.IncludeDefinition[], sharedIncludes: Types.IncludeDefinition[], usesKeyboard: Types.BoxedValue<boolean>): string {
         
         let addTextureSettingIfNew = (channel: number) => {
             if (!textureSettings.hasOwnProperty(channel)) {
@@ -493,7 +494,7 @@ void main() {
                     removeLastObject();
                     break;
                 case ObjectType.Keyboard:
-                    usesKeyboard = true;
+                    usesKeyboard.Value = true;
                     removeLastObject();
                 default:
                     break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,12 @@ export function activate(extensionContext: vscode.ExtensionContext) {
                 case 'updateKeyboard':
                     startingData.Keys = message.keys;
                     return;
+                case 'updateUniformsGuiOpen':
+                    startingData.UniformsGui.Open = message.value;
+                    return;
+                case 'updateUniformsGuiValue':
+                    startingData.UniformsGui.Values[message.name] = message.value;
+                    return;
                 case 'showGlslDiagnostic':
                     let diagnosticBatch: DiagnosticBatch = message.diagnosticBatch;
                     let severity: vscode.DiagnosticSeverity;

--- a/src/extensions/audio/audio_init_extension.ts
+++ b/src/extensions/audio/audio_init_extension.ts
@@ -33,7 +33,7 @@ export class AudioInitExtension implements WebviewExtension, TextureExtensionExt
                     path = context.makeWebviewResource(context.makeUri(localPath)).toString();
                 }
                 else if (remotePath !== undefined) {
-                    path = 'https://' + remotePath;
+                    path = remotePath;
                 }
 
                 if (path !== undefined) {

--- a/src/extensions/textures/textures_init_extension.ts
+++ b/src/extensions/textures/textures_init_extension.ts
@@ -55,9 +55,7 @@ export class TexturesInitExtension implements WebviewExtension {
                 }
             })();
 
-            let textureFileOrigin = (texture.MagLine ? texture.MagLine.File : undefined)
-                || (texture.MinLine ? texture.MinLine.File : undefined)
-                || (texture.WrapLine ? texture.WrapLine.File : undefined);
+            let textureFileOrigin = texture.File;
             let hasCustomSettings = texture.MagLine !== undefined || texture.MinLine !== undefined || texture.WrapLine !== undefined || textureFileOrigin !== undefined;
             let powerOfTwoWarning = `\
 function isPowerOfTwo(n) {
@@ -66,17 +64,17 @@ function isPowerOfTwo(n) {
 if (!isPowerOfTwo(texture.image.width) || !isPowerOfTwo(texture.image.height)) {
     let diagnostics = [];
     ${texture.MagLine !== undefined ? `diagnostics.push({
-            line: ${texture.MagLine.Line},
+            line: ${texture.MagLine},
             message: 'Texture is not power of two, custom texture settings may not work.'
         });` : ''
     }
     ${texture.MinLine !== undefined ? `diagnostics.push({
-            line: ${texture.MinLine.Line},
+            line: ${texture.MinLine},
             message: 'Texture is not power of two, custom texture settings may not work.'
         });` : ''
     }
     ${texture.WrapLine !== undefined ? `diagnostics.push({
-            line: ${texture.WrapLine.Line},
+            line: ${texture.WrapLine},
             message: 'Texture is not power of two, custom texture settings may not work.'
         });` : ''
     }
@@ -135,7 +133,7 @@ function(err) {
                     textureLoadScript = `texLoader.load('${resolvedPathString}', ${textureOnLoadScript(texture, Number(i), channel)}, undefined, ${makeTextureLoadErrorScript(resolvedPathString)})`;
                 }
                 else if (remotePath !== undefined && texture.Mag !== undefined && texture.Min !== undefined && texture.Wrap !== undefined) {
-                    textureLoadScript = `texLoader.load('https://${remotePath}', ${textureOnLoadScript(texture, Number(i), channel)}, undefined, ${makeTextureLoadErrorScript(`https://${remotePath}`)})`;
+                    textureLoadScript = `texLoader.load('${remotePath}', ${textureOnLoadScript(texture, Number(i), channel)}, undefined, ${makeTextureLoadErrorScript(`${remotePath}`)})`;
                 }
 
                 if (textureLoadScript !== undefined) {

--- a/src/extensions/uniforms/uniforms_init_extension.ts
+++ b/src/extensions/uniforms/uniforms_init_extension.ts
@@ -6,12 +6,12 @@ import { WebviewExtension } from '../webview_extension';
 export class UniformsInitExtension implements WebviewExtension {
     private content: string;
 
-    constructor(buffers: Types.BufferDefinition[]) {
+    constructor(buffers: Types.BufferDefinition[], startingState: Types.UniformsGuiStartingData) {
         this.content = '';
-        this.processBuffers(buffers);
+        this.processBuffers(buffers, startingState);
     }
 
-    private processBuffers(buffers: Types.BufferDefinition[]) {
+    private processBuffers(buffers: Types.BufferDefinition[], startingState: Types.UniformsGuiStartingData) {
         let has_uniforms = false;
         for (let buffer of buffers) {
             if (buffer.CustomUniforms.length > 0) {
@@ -22,7 +22,7 @@ export class UniformsInitExtension implements WebviewExtension {
 
         if (has_uniforms) {
             this.content += `
-let dat_gui = new dat.GUI({ autoPlace: false, closed: true });
+let dat_gui = new dat.GUI({ autoPlace: false, closed: ${!startingState.Open} });
 var dat_gui_container = document.getElementById('dat_gui_container');
 dat_gui_container.appendChild(dat_gui.domElement);
 `;
@@ -40,19 +40,30 @@ buffers[${i}].UniformValues = {};
             for (let uniform of uniforms) {
                 let uniform_values = `buffers[${i}].UniformValues`;
                 let threeType = this.mapArrayToThreeType(uniform.Default);
+
+                let defaultValue = uniform.Default;
+                if (defaultValue.length === 3) {
+                    for (let i in defaultValue) {
+                        defaultValue[i] = defaultValue[i] * 255.0;
+                    }
+                }
+                if (startingState.Values.hasOwnProperty(uniform.Name)) {
+                    defaultValue = startingState.Values[uniform.Name];
+                }
+
                 if (threeType === 'number') {
                     this.content += `\
-${uniform_values}.${uniform.Name} = ${uniform.Default};
+${uniform_values}.${uniform.Name} = ${defaultValue};
 `;
                 }
                 else {
                     this.content += `\
-${uniform_values}.${uniform.Name} = [${uniform.Default}];
+${uniform_values}.${uniform.Name} = [${defaultValue}];
 `;
                 }
 
                 this.content += `\
-${this.getDatGuiValueString(uniform_values, uniform.Name, uniform)};
+${this.getDatGuiValueString(uniform_values, uniform.Name, uniform)}
 `;
             }
         }
@@ -60,16 +71,37 @@ ${this.getDatGuiValueString(uniform_values, uniform.Name, uniform)};
 
     private getDatGuiValueString(object: string, property: string, value: Types.UniformDefinition) {
         if (value.Default.length === 1) {
-            let min = value.Min ? `.min(${value.Min})` : '';
-            let max = value.Max ? `.max(${value.Max})` : '';
-            let step = value.Step ? `.step(${value.Step})` : '';
-            return `dat_gui.add(${object}, '${property}')${min}${max}${step}`;
+            return `\
+{
+    let controller = ${this.getRawDatGuiValueString(object, property, value)};
+    controller.onFinishChange((value) => {
+        vscode.postMessage({
+            command: 'updateUniformsGuiValue',
+            name: '${value.Name}',
+            value: [ value ]
+        });
+    });
+}
+`;
         }
         else if (value.Default.length === 3 && !value.Min && !value.Max && !value.Step) {
-            return `dat_gui.addColor(${object}, '${property}')`;
+            return `\
+{
+    let controller = ${this.getRawDatGuiValueString(object, property, value)};
+    controller.onFinishChange((value) => {
+        vscode.postMessage({
+            command: 'updateUniformsGuiValue',
+            name: '${value.Name}',
+            value: value
+        });
+    });
+}
+`;
         }
         else {
-            let datGuiString = '';
+            let datGuiString = `{
+    let values = [];
+`;
             let sub_object = `${object}.${property}`;
             for (let i = 0; i < value.Default.length; i++) {
                 let sub_value: Types.UniformDefinition = {
@@ -80,12 +112,35 @@ ${this.getDatGuiValueString(uniform_values, uniform.Name, uniform)};
                     Max: value.Max ? [ value.Max[i] ] : undefined,
                     Step: value.Step ? [ value.Step[i] ] : undefined,
                 };
-                datGuiString += `
-${this.getDatGuiValueString(sub_object, sub_value.Name, sub_value)}.name('${property}.${sub_value.Name}');`;
+                datGuiString += `\
+    values.push(${sub_value.Default[0]});
+    let controller_${i} = ${this.getRawDatGuiValueString(sub_object, sub_value.Name, sub_value)}.name('${property}.${sub_value.Name}');
+    controller_${i}.onFinishChange((value) => {
+        values[${i}] = value;
+        vscode.postMessage({
+            command: 'updateUniformsGuiValue',
+            name: '${value.Name}',
+            value: values
+        });
+    });
+`;
             }
+            datGuiString += '}';
             return datGuiString;
         }
     }
+    private getRawDatGuiValueString(object: string, property: string, value: Types.UniformDefinition) {
+        if (value.Default.length === 1) {
+            let min = value.Min ? `.min(${value.Min})` : '';
+            let max = value.Max ? `.max(${value.Max})` : '';
+            let step = value.Step ? `.step(${value.Step})` : '';
+            return `dat_gui.add(${object}, '${property}')${min}${max}${step}`;
+        }
+        else if (value.Default.length === 3 && !value.Min && !value.Max && !value.Step) {
+            return `dat_gui.addColor(${object}, '${property}')`;
+        }   
+    }
+    
     private indexToDimension(index: number) {
         let dimensionStrings = [ 'x', 'y', 'z', 'w' ];
         return dimensionStrings[index];

--- a/src/extensions/uniforms/uniforms_init_extension.ts
+++ b/src/extensions/uniforms/uniforms_init_extension.ts
@@ -22,7 +22,7 @@ export class UniformsInitExtension implements WebviewExtension {
 
         if (has_uniforms) {
             this.content += `
-let dat_gui = new dat.GUI({ autoPlace: false });
+let dat_gui = new dat.GUI({ autoPlace: false, closed: true });
 var dat_gui_container = document.getElementById('dat_gui_container');
 dat_gui_container.appendChild(dat_gui.domElement);
 `;
@@ -74,6 +74,7 @@ ${this.getDatGuiValueString(uniform_values, uniform.Name, uniform)};
             for (let i = 0; i < value.Default.length; i++) {
                 let sub_value: Types.UniformDefinition = {
                     Name: this.indexToDimension(i),
+                    Typename: value.Typename[0] === 'i' ? "integer" : "float",
                     Default: [ value.Default[i] ],
                     Min: value.Min ? [ value.Min[i] ] : undefined,
                     Max: value.Max ? [ value.Max[i] ] : undefined,

--- a/src/extensions/uniforms/uniforms_preamble_extension.ts
+++ b/src/extensions/uniforms/uniforms_preamble_extension.ts
@@ -15,25 +15,10 @@ export class UniformsPreambleExtension implements WebviewExtension {
         for (let buffer of buffers) {
             let uniforms = buffer.CustomUniforms;
             for (let uniform of uniforms) {
-                let glslType = this.mapArrayToGlslType(uniform.Default);
                 this.content += `\
-uniform ${glslType} ${uniform.Name};
+uniform ${uniform.Typename} ${uniform.Name};
 `;
             }
-        }
-    }
-
-    private mapArrayToGlslType(value: number[]) {
-        let l = value.length;
-        switch (l) {
-            case 1:
-                return 'float';
-            case 2:
-            case 3:
-            case 4:
-                return `vec${l}`;
-            default:
-                return 'error_type';
         }
     }
 

--- a/src/extensions/uniforms/uniforms_update_extension.ts
+++ b/src/extensions/uniforms/uniforms_update_extension.ts
@@ -17,11 +17,23 @@ export class UniformsUpdateExtension implements WebviewExtension {
             let uniforms = buffer.CustomUniforms;
             for (let uniform of uniforms) {
                 let uniform_access = `buffers[${i}].UniformValues.${uniform.Name}`;
+                if (uniform.Default.length === 3) {
+                    this.content += `\
+let ${uniform.Name} = [ ${uniform_access}[0] / 255.0, ${uniform_access}[1] / 255.0, ${uniform_access}[2] / 255.0 ];
+`;
+                    uniform_access = uniform.Name;
+                }
                 this.content += `\
 buffers[${i}].Shader.uniforms.${uniform.Name} = { type: '${this.mapArrayToShaderType(uniform.Default)}', value: ${uniform_access} };
 `;
             }
         }
+        this.content += `\
+vscode.postMessage({
+    command: 'updateUniformsGuiOpen',
+    value: !dat_gui.closed
+});
+`;
     }
 
     private mapArrayToShaderType(value: number[]) {

--- a/src/glsl_extension_grammar.txt
+++ b/src/glsl_extension_grammar.txt
@@ -1,0 +1,46 @@
+statement = "#" command
+
+command =
+      "include" string
+    | "iChannel" number ( string | texture_parameter )
+    | "iKeyboard"
+    | "iUniform" uniform
+
+texture_parameter = "::" ( min_filter | mag_filter | wrap_mode )
+
+min_filter = "MinFilter"
+    ( "Nearest"
+    | "NearestMipMapNearest"
+    | "NearestMipMapLinear"
+    | "Linear"
+    | "LinearMipMapNearest"
+    | "LinearMipMapLinear" )
+
+mag_filter = "MagFilter"
+    ( "Nearest"
+    | "Linear")
+
+wrap_mode = "WrapMode"
+    ( "Repeat"
+    | "Clamp"
+    | "Mirror")
+
+uniform = type identifier [ "=" value ] [ "in" range ]
+
+range = "[" value "," value "]"
+
+value = decimal | number | ( type "(" parameters ")" )
+
+parameters = [ value { "," value } ]
+
+decimal = number "." number
+
+type =
+      "int"
+    | "ivec2"
+    | "ivec3"
+    | "ivec4"
+    | "float"
+    | "vec2"
+    | "vec3"
+    | "vec4"

--- a/src/shaderlexer.ts
+++ b/src/shaderlexer.ts
@@ -11,7 +11,8 @@ export enum TokenType {
     Identifier,
     PreprocessorKeyword,
     Keyword,
-    Type
+    Type,
+    Unkown
 }
 export type Token = {
     type: TokenType,
@@ -117,7 +118,7 @@ export class ShaderLexer {
         return ShaderLexer.is_identifier_start(val) || /[0-9]/i.test(val) || "_".indexOf(val) >= 0;
     }
     private static is_operator(val: string) {
-        return "=*/+-%~&|<>?".indexOf(val) >= 0;
+        return "=*/+-%~&|<>?!".indexOf(val) >= 0;
     }
     private static is_punctuation(val: string) {
         return ".,:;()[]{}".indexOf(val) >= 0;
@@ -189,21 +190,26 @@ export class ShaderLexer {
                 this.stream.next();
                 return {
                     type: TokenType.Punctuation,
-                    value : '::'
+                    value: '::'
                 };
             }
 
             return {
                 type: TokenType.Punctuation,
-                value : this.stream.next()
+                value: this.stream.next()
             };
         }
         if (ShaderLexer.is_operator(next_peek)) {
             return {
                 type: TokenType.Operator,
-                value : this.stream.next()
+                value: this.stream.next()
             };
         }
+
+        return {
+            type: TokenType.Unkown,
+            value: next_peek
+        };
     }
 
     private next_while(predicate: (_: string) => boolean) {

--- a/src/shaderlexer.ts
+++ b/src/shaderlexer.ts
@@ -1,0 +1,272 @@
+'use strict';
+
+import { ShaderStream } from './shaderstream';
+
+export enum TokenType {
+    Punctuation,
+    Operator,
+    String,
+    Integer,
+    Float,
+    Identifier,
+    PreprocessorKeyword,
+    Keyword,
+    Type
+}
+export type Token = {
+    type: TokenType,
+    value: any
+};
+
+export type LineRange = {
+    Begin: number,
+    End: number
+};
+
+export class ShaderLexer {
+    private stream: ShaderStream;
+    private currentPeek: Token | undefined;
+
+    private currentPeekRange: LineRange;
+    private currentRange: LineRange;
+
+    constructor(stream: ShaderStream) {
+        this.stream = stream;
+        this.currentPeekRange = { Begin: 0, End: 0 };
+        this.currentRange = { Begin: 0, End: 0 };
+    }
+    
+    public reset(content: string, position: number) {
+        this.stream.reset(content, position);
+        this.currentPeek = undefined;
+    }
+
+    public eof() {
+        return this.stream.eof();
+    }
+    public getCurrentLine() {
+        return this.stream.getCurrentLine();
+    }
+
+    public peek(): Token | undefined {
+        if (this.currentPeek === undefined) {
+            this.currentPeek = this.read_next();
+            this.currentPeekRange.End = this.stream.pos();
+        }
+        return this.currentPeek;
+    }
+    public next(): Token | undefined {
+        let token = this.peek();
+        this.currentPeek = undefined;
+        this.currentRange.Begin = this.currentPeekRange.Begin;
+        this.currentRange.End = this.currentPeekRange.End;
+        return token;
+    }
+
+    public getLastRange(): LineRange {
+        return this.currentRange;
+    }
+
+    private static preprocessor_keywords = [
+        'include',
+        'iKeyboard',
+        'iUniform'
+    ];
+    private is_preprocessor_keyword(val: string) {
+        let idx = ShaderLexer.preprocessor_keywords.indexOf(val);
+        if (idx >= 0) {
+            return true;
+        }
+        return val.indexOf('iChannel') === 0;
+    }
+    private static keywords = [
+        'MinFilter',
+        'MagFilter',
+        'WrapMode',
+        'in'
+    ];
+    private is_keyword(val: string) {
+        return ShaderLexer.keywords.indexOf(val) > 0;
+    }
+    private static types = [
+        'float',
+        'vec2',
+        'vec3',
+        'vec4',
+        'int',
+        'ivec2',
+        'ivec3',
+        'ivec4'
+    ];
+    private static is_type(val: string) {
+        return ShaderLexer.types.indexOf(val) >= 0;
+    }
+    private static is_quotation(val: string) {
+        return "'\"".indexOf(val) >= 0;
+    }
+    private static is_digit(val: string) {
+        return /[0-9]/i.test(val);
+    }
+    private static is_preprocessor_start(val: string) {
+        return val === "#";
+    }
+    private static is_identifier_start(val: string) {
+        return /[a-z_]/i.test(val);
+    }
+    private static is_identifier(val: string) {
+        return ShaderLexer.is_identifier_start(val) || /[0-9]/i.test(val) || "_".indexOf(val) >= 0;
+    }
+    private static is_operator(val: string) {
+        return "=*/+-%~&|<>?".indexOf(val) >= 0;
+    }
+    private static is_punctuation(val: string) {
+        return ".,:;()[]{}".indexOf(val) >= 0;
+    }
+    private static is_whitespace(val: string) {
+        return " \t\r\n\\".indexOf(val) >= 0;
+    }
+    private static is_endline(val: string) {
+        return "\n".indexOf(val) >= 0;
+    }
+    private static not(predicate: (_: string) => boolean) {
+        return (val: string) => {
+            return !predicate(val);
+        };
+    }
+
+    private read_next(): Token | undefined {
+        if (this.stream.eof()) {
+            return undefined;
+        }
+
+        if (this.currentPeek !== undefined) {
+            return this.currentPeek;
+        }
+        
+        // Skip whitespace
+        this.next_while(ShaderLexer.is_whitespace);
+
+        // Skip comments
+        if (this.stream.peek() === '/') {
+            if (this.stream.peek(1) === '/') {
+                this.next_while(ShaderLexer.not(ShaderLexer.is_endline));
+                this.stream.next();
+            }
+            else if (this.stream.peek(1) === '*') {
+                this.stream.next();
+                this.stream.next();
+                do {
+                    this.next_while((val: string) => val !== '*');
+                    this.stream.next();
+                } while (this.stream.next() !== '/');
+            }
+        }
+
+        this.currentPeekRange.Begin = this.stream.pos();
+
+        let next_peek = this.stream.peek();
+        if (ShaderLexer.is_quotation(next_peek)) {
+            return this.next_string(next_peek);
+        }
+        if (ShaderLexer.is_digit(next_peek)) {
+            return this.next_number();
+        }
+        if (ShaderLexer.is_identifier_start(next_peek)) {
+            return this.next_identifier();
+        }
+        if (ShaderLexer.is_preprocessor_start(next_peek)) {
+            this.stream.next();
+            let identifier = this.next_identifier();
+            if (identifier !== undefined && this.is_preprocessor_keyword(identifier.value)) {
+                identifier.type = TokenType.PreprocessorKeyword;
+                return identifier;
+            }
+            return undefined;
+        }
+        if (ShaderLexer.is_punctuation(next_peek)) {
+            if (next_peek === ':' && this.stream.peek(1) === ':') {
+                this.stream.next();
+                this.stream.next();
+                return {
+                    type: TokenType.Punctuation,
+                    value : '::'
+                };
+            }
+
+            return {
+                type: TokenType.Punctuation,
+                value : this.stream.next()
+            };
+        }
+        if (ShaderLexer.is_operator(next_peek)) {
+            return {
+                type: TokenType.Operator,
+                value : this.stream.next()
+            };
+        }
+    }
+
+    private next_while(predicate: (_: string) => boolean) {
+        let str = '';
+        while (!this.stream.eof() && predicate(this.stream.peek())) {
+            str += this.stream.next();
+        }
+        return str;
+    }
+    private next_number(): Token {
+        let has_dot = false;
+        let number = this.next_while((val: string) => {
+            if (val === ".") {
+                if (has_dot) {
+                    return false;
+                }
+                has_dot = true;
+                return true;
+            }
+            return ShaderLexer.is_digit(val);
+        });
+        return {
+            type: has_dot ? TokenType.Float : TokenType.Integer,
+            value: parseFloat(number)
+        };
+    }
+    private next_identifier(): Token {
+        let id = this.next_while(ShaderLexer.is_identifier);
+        let type = TokenType.Identifier;
+        if (this.is_keyword(id)) {
+            type = TokenType.Keyword;
+        }
+        else if (ShaderLexer.is_type(id)) {
+            type = TokenType.Type;
+        }
+        return {
+            type: type,
+            value: id
+        };
+    }
+    private next_string(quotation: string): Token {
+        let escaped = false;
+        let str = '';
+        this.stream.next();
+        while (!this.stream.eof()) {
+            let val = this.stream.next();
+            if (escaped) {
+                str += val;
+                escaped = false;
+            }
+            else if (val === '\\') {
+                escaped = true;
+            }
+            else if (val === quotation) {
+                break;
+            }
+            else {
+                str += val;
+            }
+        }
+        return {
+            type: TokenType.String,
+            value: str
+        };
+    }
+}

--- a/src/shaderparser.ts
+++ b/src/shaderparser.ts
@@ -1,762 +1,540 @@
 'use strict';
 
-import * as vscode from 'vscode';
-import * as mime from 'mime';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as Types from'./typenames';
-import { Context } from './context';
+import { ShaderStream } from './shaderstream';
+import { ShaderLexer, Token, TokenType, LineRange } from './shaderlexer';
+
+export enum ObjectType {
+    Include,
+    Texture,
+    TextureMagFilter,
+    TextureMinFilter,
+    TextureWrapMode,
+    Number,
+    Value,
+    Uniform,
+    Keyboard,
+    Error
+}
+type Include = {
+    Type: ObjectType.Include,
+    Path: string
+};
+type Texture = {
+    Type: ObjectType.Texture,
+    Index: number,
+    Path: string
+};
+type TextureMagFilter = {
+    Type: ObjectType.TextureMagFilter,
+    Index: number,
+    Value: Types.TextureMagFilter
+};
+type TextureMinFilter = {
+    Type: ObjectType.TextureMinFilter,
+    Index: number,
+    Value: Types.TextureMinFilter
+};
+type TextureWrapMode = {
+    Type: ObjectType.TextureWrapMode,
+    Index: number,
+    Value: Types.TextureWrapMode
+};
+type LiteralNumber = {
+    Type: ObjectType.Number,
+    ValueType: string,
+    LiteralString: string,
+    Value: number
+};
+type LiteralValue = {
+    Type: ObjectType.Value,
+    ValueType: string,
+    LiteralString: string,
+    Value: LiteralNumber[] | LiteralValue[]
+};
+type Uniform = {
+    Type: ObjectType.Uniform,
+    Name: string,
+    Typename: string,
+    Default?: number[],
+    Min?: number[],
+    Max?: number[],
+    Step?: number[]
+};
+type Keyboard = {
+    Type: ObjectType.Keyboard
+};
+type ErrorObject = {
+    Type: ObjectType.Error,
+    Message: string
+};
+type TextureObject = Texture | TextureMagFilter | TextureMinFilter | TextureWrapMode;
+type Object = Include | TextureObject | Uniform | Keyboard;
 
 export class ShaderParser {
-    private context: Context;
-    private visitedFiles: string[];
-    constructor(context: Context) {
-        this.context = context;
-        this.visitedFiles = [];
+    private stream: ShaderStream;
+    private lexer: ShaderLexer;
+    private lastObjectRange: LineRange | undefined;
+
+    constructor(content: string) {
+        this.stream = new ShaderStream(content);
+        this.lexer = new ShaderLexer(this.stream);
+        this.lastObjectRange = undefined;
     }
 
-    public parseShaderCode(file: string, code: string, buffers: Types.BufferDefinition[], commonIncludes: Types.IncludeDefinition[]) {
-        this.parseShaderCodeInternal(file, code, buffers, commonIncludes);
+    public reset(content: string, position: number) {
+        this.lexer.reset(content, position);
+    }
 
-        const findByName = (bufferName: string) => {
-            let strippedName = this.stripPath(bufferName);
-            return (value: any) => {
-                if (value.Name === strippedName) {
-                    return true;
-                }
-                return false;
-            };
+    public eof(): boolean {
+        return this.stream.eof();
+    }
+
+    public line(): number {
+        return this.stream.line();
+    }
+
+    public getLastObjectRange(): LineRange | undefined {
+        return this.lastObjectRange;
+    }
+
+    public next(): Object | ErrorObject | undefined {
+        let nextToken = this.lexer.next();
+        while (!this.lexer.eof() && (nextToken === undefined || nextToken.type !== TokenType.PreprocessorKeyword)) {
+            nextToken = this.lexer.next();
+        }
+        if (this.lexer.eof() || nextToken === undefined) {
+            return undefined;
+        }
+
+        let rangeBegin = this.lexer.getLastRange().Begin;
+
+        let tokenValue = nextToken.value as string;
+        let returnObject: Object | ErrorObject;
+        switch (tokenValue) {
+            case 'include':
+                returnObject = this.getInclude();
+                break;
+            case 'iKeyboard':
+                let keyboard: Keyboard = {
+                    Type: ObjectType.Keyboard
+                };
+                returnObject = keyboard;
+            case 'iUniform':
+                returnObject = this.getUniformObject();
+                break;
+            default: // Must be iChannel
+                returnObject = this.getTextureObject(nextToken);
+                break;
+        }
+
+        let rangeEnd = this.lexer.getLastRange().End;
+        this.lastObjectRange = { Begin: rangeBegin, End: rangeEnd };
+
+        returnObject = returnObject || {
+            Type: ObjectType.Error,
+            Message: `Unkown error while parsing for custom features`
         };
-
-        // Translate buffer names to indices including self reads
-        for (let i = 0; i < buffers.length; i++) {
-            let buffer = buffers[i];
-            let usesSelf = false;
-            let selfChannel = 0;
-            for (let j = 0; j < buffer.TextureInputs.length; j++) {
-                let texture = buffer.TextureInputs[j];
-                if (texture.Buffer) {
-                    texture.BufferIndex = buffers.findIndex(findByName(texture.Buffer));
-                }
-                else if (texture.Self) {
-                    texture.Buffer = buffer.Name;
-                    texture.BufferIndex = i;
-                    usesSelf = true;
-                    selfChannel = j;
-                }
-            }
-
-            buffer.UsesSelf = usesSelf;
-            buffer.SelfChannel = selfChannel;
-        }
-
-        // Resolve dependencies between passes
-        for (let i = 0; i < buffers.length; i++) {
-            let buffer = buffers[i];
-            for (let texture of buffer.TextureInputs) {
-                if (!texture.Self && texture.Buffer !== undefined && texture.BufferIndex !== undefined) {
-                    let dependencyBuffer = buffers[texture.BufferIndex];
-                    if (dependencyBuffer.UsesSelf) {
-                        dependencyBuffer.Dependents.push({
-                            Index: i,
-                            Channel: texture.Channel
-                        });
-                    }
-                }
-            }
-        }
+        return returnObject;
     }
 
-    private readShaderFile(file: string): { success: boolean, error: any, bufferCode: string } {
-        for (let editor of vscode.window.visibleTextEditors) {
-            let editorFile = editor.document.fileName;
-            editorFile = editorFile.replace(/\\/g, '/');
-            if (editorFile === file) {
-                return { success: true, error: null, bufferCode: editor.document.getText() };
-            }
+    private getInclude(): Include | ErrorObject {
+        let nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected string after "include" but got end-of-file`);
+        }
+        if (nextToken.type !== TokenType.String) {
+            return this.makeError(`Expected string after "include" but got "${nextToken.value}"`);
         }
 
-        // Read the whole file of the shader
-        let success = false;
-        let bufferCode = '';
-        let error = null;
-        try {
-            bufferCode = fs.readFileSync(file, 'utf-8');
-            success = true;
-        }
-        catch (e) {
-            error = e;
-        }
-
-        return { success, error, bufferCode };
-    }
-    private stripPath(name: string): string{
-        let lastSlash = name.lastIndexOf('/');
-        return name.substring(lastSlash + 1);
-    }
-
-    private mapUserPathToWorkspacePath(userPath: string): { file: string, userPath: string } {
-        userPath = userPath.replace(/\\/g, '/');
-
-        let file = ((file: string) => {
-            const relFile = vscode.workspace.asRelativePath(file);
-            const herePos = relFile.indexOf('./');
-            if (vscode.workspace.workspaceFolders === undefined && herePos === 0) {
-                vscode.window.showErrorMessage('To use relative paths please open a workspace!');
-            }
-            if ((relFile !== file || herePos === 0) && vscode.workspace.workspaceFolders !== undefined) {
-                let fileCandidates: string[] = [];
-                for (let worspaceFolder of vscode.workspace.workspaceFolders) {
-                    let fileCandidate = worspaceFolder.uri.fsPath + '/' + relFile;
-                    fileCandidate = fileCandidate.replace(/\\/g, '/');
-                    fileCandidate = fileCandidate.replace(/\.\//g, '');
-                    if (fs.existsSync(fileCandidate)) {
-                        fileCandidates.push(fileCandidate);
-                    }
-                }
-
-                if (fileCandidates.length === 0) {
-                    vscode.window.showErrorMessage(`No candidates for file '${userPath}' were found in your workspace folders.`);
-                }
-                else if (fileCandidates.length > 1) {
-                    vscode.window.showErrorMessage(`Multiple candidates for file '${userPath}' were found in your workspace folders, first option was picked: '${fileCandidates[0]}'`);
-                }
-
-                return fileCandidates[0];
-            }
-            else {
-                return file;
-            }
-        })(userPath);
-        return { file, userPath };
-    }
-
-    private parseIncludeCodeInternal(file: string, commonIncludes: Types.IncludeDefinition[]): Types.IncludeDefinition {
-        let userPath = file;
-        ({ file, userPath } = this.mapUserPathToWorkspacePath(userPath));
-
-        const name = path.basename(file);
-        
-        // Read the whole file of the shader
-        const shaderFile = this.readShaderFile(file);
-        if(shaderFile.success === false){
-            vscode.window.showErrorMessage(`Could not open file: ${userPath}`);
-            return {
-                Name: name,
-                File: file,
-                Code: '',
-                LineCount: 0
-            };
-        }
-        let code = shaderFile.bufferCode;
-
-        let includeMatch = code.match(/#include/m);
-        while (includeMatch && includeMatch.index !== undefined && includeMatch.index >= 0) {
-            let includePos = includeMatch.index;
-            let endlineMatch = code.substring(includePos).match(/\r\n|\r|\n/);
-            if (endlineMatch !== null && endlineMatch.index !== undefined) {
-                endlineMatch.index += includePos;
-                let endlinePos = endlineMatch.index + endlineMatch[0].length;
-                let line = code.substring(includePos, endlineMatch.index);
-
-                let leftQuotePos = line.search(/"|'/);
-                let rightQuotePos = line.substring(leftQuotePos + 1).search(/"|'/) + leftQuotePos + 1;
-
-                if (leftQuotePos < 0 || rightQuotePos < 0) {
-                    if (this.context.getConfig<boolean>('omitDeprecationWarnings') === false) {
-                        vscode.window.showErrorMessage('Nested includes have to use non-deprecated syntax, i.e. use quotes and omit a scheme.');
-                    }
-                }
-                else {
-                    let quotedPart = line.substring(leftQuotePos + 1, rightQuotePos).trim();
-                    let nestedInclude = this.parseIncludeCodeInternal(quotedPart, commonIncludes);
-                    code = code.replace(line, nestedInclude.Code);
-                }
-            }
-            includeMatch = code.match(/#include/m);
-        }
-
-        let include = {
-            Name: name,
-            File: file,
-            Code: code,
-            LineCount: code.split(/\r\n|\n/).length
+        let tokenValue = nextToken.value as string;
+        let include: Include = {
+            Type: ObjectType.Include,
+            Path: tokenValue
         };
-
-        commonIncludes.push(include);
         return include;
     }
 
-    private parseShaderCodeInternal(file: string, code: string, buffers: Types.BufferDefinition[], commonIncludes: Types.IncludeDefinition[]) {
-        const found = this.visitedFiles.find((visitedFile: string) => visitedFile === file);
-        if (found) {
-            return;
+    private getTextureObject(previous: Token): Texture | TextureMagFilter | TextureMinFilter | TextureWrapMode | ErrorObject {
+        let nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected string or "::" after "${previous.value}" but got end-of-file`);
         }
-        this.visitedFiles.push(file);
+        if (nextToken.type !== TokenType.String &&
+            nextToken.value !== '::') {
+            return this.makeError(`Expected string or "::" after "${previous.value}" but got "${nextToken.value}"`);
+        }
 
-        let line_offset = 0;
-        let textures: Types.TextureDefinition[] = [];
-        let pendingTextureSettings: Types.TextureDefinition[] = [];
-        let audios: Types.AudioDefinition[] = [];
-        let uniforms: Types.UniformDefinition[] = [];
-        let includes: string[] = [];
+        let channelName = previous.value as string;
+        let index = parseInt(channelName.replace('iChannel', ''));
 
-        const loadDependency = (depFile: string, channel: number, passType: string, codePosition: number) => {
-            // Get type and name of file
-            let colonPos = depFile.indexOf('://', 0);
-            
-            let inputType = 'file';
-            let userPath = depFile;
+        if (nextToken.type === TokenType.Punctuation) {
+            return this.getTextureParameter(index);            
+        }
 
-            if (colonPos >= 0) {
-                inputType = depFile.substring(0, colonPos);
-                userPath = depFile.substring(colonPos + 3, depFile.length);
-            }
-
-            ({ file: depFile, userPath } = this.mapUserPathToWorkspacePath(userPath));
-
-            if (inputType !== 'file' && inputType !== 'https') {
-                if (this.context.getConfig<boolean>('omitDeprecationWarnings') === false) {
-                    if (passType === 'include') {
-                        vscode.window.showWarningMessage(`You are using deprecated input methods, no protocol is required for includes, simply use '#include './file.glsl''`);
-                    }
-                    else {
-                        vscode.window.showWarningMessage(`You are using deprecated input methods, use 'file://' or 'https://', the type of input will be inferred.`);
-                    }
-                }
-                inputType = 'file';
-            }
-
-            let isLocalFile: boolean = inputType === 'file';
-            let fileType = depFile.split('.').pop();
-            let fullMime = mime.getType(fileType || 'txt') || 'text/plain';
-            let mimeType = fullMime.split('/')[0] || 'text';
-
-            if (passType === 'include') {
-                const name = path.basename(depFile);
-
-                // Attempt to get the include if already exists
-                let include = commonIncludes.find(include => include.File === depFile);
-                if (include === undefined) {
-                    include = this.parseIncludeCodeInternal(userPath, commonIncludes);
-                }
-
-                // offset the include line count
-                line_offset += include.LineCount - 1;
-
-                // Directly insert include into code
-                code = code.substring(0, codePosition) + include.Code + code.substring(codePosition);
-
-                // store the reference name for this include
-                includes.push(name);
-            }
-            else {
-                switch (mimeType) {
-                    case 'text': {
-                        if (depFile === 'self' || depFile === file) {
-                            // Push self as feedback-buffer
-                            textures.push({
-                                Channel: channel,
-                                Self: true
-                            });
-                        }
-                        else {
-                            // Read the whole file of the shader
-                            const shaderFile = this.readShaderFile(depFile);
-                            if(shaderFile.success === false){
-                                vscode.window.showErrorMessage(`Could not open file: ${userPath}`);
-                                return;
-                            }
-        
-                            // Parse the shader
-                            this.parseShaderCodeInternal(depFile, shaderFile.bufferCode, buffers, commonIncludes);
-                
-                            // Push buffers as textures
-                            textures.push({
-                                Channel: channel,
-                                Buffer: this.stripPath(depFile),
-                            });
-                        }
-                        break;
-                    }
-                    case 'image': {
-                        if (isLocalFile) {
-                            textures.push({
-                                Channel: channel,
-                                LocalTexture: depFile,
-                                Mag: Types.TextureMagFilter.Linear,
-                                Min: Types.TextureMinFilter.Linear,
-                                Wrap: Types.TextureWrapMode.Clamp
-                            });
-                        }
-                        else {
-                            textures.push({
-                                Channel: channel,
-                                RemoteTexture: depFile,
-                                Mag: Types.TextureMagFilter.Linear,
-                                Min: Types.TextureMinFilter.Linear,
-                                Wrap: Types.TextureWrapMode.Clamp
-                            });
-                        }
-                        break;
-                    }
-                    case 'audio': {
-                        if (this.context.getConfig<boolean>('enabledAudioInput')) {
-                            if (isLocalFile) {
-                                audios.push({
-                                    Channel: channel,
-                                    LocalPath: depFile,
-                                    UserPath: userPath
-                                });
-                            }
-                            else {
-                                audios.push({
-                                    Channel: channel,
-                                    RemotePath: depFile,
-                                    UserPath: userPath
-                                });
-                            }
-                        }
-                        else {
-                            vscode.window.showWarningMessage(`You are trying to use an audio file, which is currently disabled in the settings.`);
-                        }
-                        break;
-                    }
-                    default: {
-                        vscode.window.showWarningMessage(`You are trying to use an unsupported file ${depFile}`);
-                    }
-                }
-            }
+        let tokenValue = nextToken.value as string;
+        let texture: Texture = {
+            Type: ObjectType.Texture,
+            Index: index,
+            Path: tokenValue
         };
-
-        const getLineNumber = (position: number) => {
-            let substr = code.substring(0, position);
-            var count = (substr.match(/(\r\n|\r|\n)/g) || []).length;
-            return count - line_offset;
-        };
-
-        const showDiagnosticAtPosition = (message: string, position: number) => {
-            let diagnosticBatch: Types.DiagnosticBatch = {
-                filename: file,
-                diagnostics: [{
-                    line: getLineNumber(position),
-                    message: message
-                }]
-            };
-            this.context.showDiagnostics(diagnosticBatch, vscode.DiagnosticSeverity.Information);
-        };
-
-        let usesKeyboard = false;
-        let useTextureDefinitionInShaders = this.context.getConfig<boolean>('useInShaderTextures');
-        if (useTextureDefinitionInShaders) {
-            // Find all #iChannel defines, which define textures and other shaders
-            type Match = {
-                TexturePos: number;
-                MatchLength: number;
-                PassType: string;
-            };
-
-            const findNextMatch = (): Match | undefined => {
-                let channelMatch = code.match(/#(iChannel|include|iKeyboard|iUniform)/m);
-                if (channelMatch && channelMatch.index !== undefined && channelMatch.index >= 0) {
-                    return {
-                        TexturePos: channelMatch.index,
-                        MatchLength: channelMatch[0].length,
-                        PassType: channelMatch[1] || '',
-                    };
-                }
-                return undefined;
-            };
-            let nextMatch: Match | undefined;
-            while (nextMatch = findNextMatch()) {
-                let channelPos = nextMatch.TexturePos + nextMatch.MatchLength;
-                let endlineMatch = code.substring(channelPos).match(/\r\n|\r|\n/);
-                if (endlineMatch !== null && endlineMatch.index !== undefined) {
-                    endlineMatch.index += channelPos;
-                    let endlinePos = endlineMatch.index + endlineMatch[0].length;
-
-                    switch (nextMatch.PassType) {
-                        case 'iKeyboard': {
-                            usesKeyboard = true;
-                            break;
-                        }
-                        case 'iUniform': {
-                            let line = code.substring(channelPos, endlineMatch.index);
-                            let uniform = this.parseUniformCode(line, (message: string) => showDiagnosticAtPosition(message, endlinePos));
-                            if (uniform !== undefined) {
-                                uniforms.push(uniform);
-                            }
-                            break;
-                        }
-                        case 'iChannel':
-                        case 'include': {
-                            let line = code.substring(channelPos, endlineMatch.index);
-
-                            let leftQuotePos = line.search(/"|'/);
-                            let rightQuotePos = line.substring(leftQuotePos + 1).search(/"|'/) + leftQuotePos + 1;
-
-                            let channel: number | undefined;
-                            let input: string | undefined;
-
-                            if (leftQuotePos < 0 || rightQuotePos < 0) {
-                                if (this.context.getConfig<boolean>('omitDeprecationWarnings') === false) {
-                                    vscode.window.showWarningMessage('To use input, wrap the path/url of your input in quotes, omitting quotes is deprecated syntax.');
-                                }
-
-                                let spacePos = Math.min(code.indexOf(' ', channelPos), endlineMatch.index);
-        
-                                // Get channel number
-                                channel = parseInt(code.substring(channelPos, spacePos));
-        
-                                let afterSpacePos = code.indexOf(' ', spacePos + 1);
-                                let afterCommentPos = code.indexOf('//', code.indexOf('://', spacePos)  + 3);
-                                let textureEndPos = Math.min(endlineMatch.index,
-                                    afterSpacePos > 0 ? afterSpacePos : code.length,
-                                    afterCommentPos > 0 ? afterCommentPos : code.length);
-
-                                // Get dependencies' name
-                                input = code.substring(spacePos + 1, textureEndPos);
-                            }
-                            else {
-                                let leftPart = line.substring(0, leftQuotePos).trim();
-                                let quotedPart = line.substring(leftQuotePos + 1, rightQuotePos).trim();
-                                
-                                let scopePos = leftPart.search(/^\d+::/);
-                                if (scopePos < 0) {
-                                    channel = parseInt(leftPart);
-                                    input = quotedPart;
-                                }
-                                else {
-                                    scopePos = leftPart.search('::');
-
-                                    let magFilter: Types.TextureMagFilter | undefined;
-                                    let minFilter: Types.TextureMinFilter | undefined;
-                                    let wrapMode: Types.TextureWrapMode | undefined;
-
-                                    let channelPart = leftPart.substring(0, scopePos);
-                                    channel = parseInt(channelPart);
-
-                                    let settingName = leftPart.substring(scopePos + 2);
-                                    switch (settingName) {
-                                        case 'MagFilter':
-                                            magFilter = (() => {
-                                                switch(quotedPart) {
-                                                    case 'Nearest':
-                                                        return Types.TextureMagFilter.Nearest;
-                                                    case 'Linear':
-                                                        return Types.TextureMagFilter.Linear;
-                                                    default:
-                                                        showDiagnosticAtPosition(`Valid MagFilter options are: 'Nearest' or 'Linear'`, endlinePos);
-                                                }
-                                            })();
-
-                                            break;
-                                        case 'MinFilter':
-                                            minFilter = (() => {
-                                                switch(quotedPart) {
-                                                    case 'Nearest':
-                                                        return Types.TextureMinFilter.Nearest;
-                                                    case 'NearestMipMapNearest':
-                                                        return Types.TextureMinFilter.NearestMipMapNearest;
-                                                    case 'NearestMipMapLinear':
-                                                        return Types.TextureMinFilter.NearestMipMapLinear;
-                                                    case 'Linear':
-                                                        return Types.TextureMinFilter.Linear;
-                                                    case 'LinearMipMapNearest':
-                                                        return Types.TextureMinFilter.LinearMipMapNearest;
-                                                    case 'LinearMipMapLinear':
-                                                        return Types.TextureMinFilter.LinearMipMapLinear;
-                                                    default:
-                                                        showDiagnosticAtPosition(`Valid MinFilter options are: 'Nearest', 'NearestMipMapNearest', 'NearestMipMapLinear', 'Linear', 'LinearMipMapNearest' or 'LinearMipMapLinear'`, endlinePos);
-                                                }
-                                            })();
-
-                                            break;
-                                        case 'WrapMode':
-                                            wrapMode = (() => {
-                                                switch(quotedPart) {
-                                                    case 'Repeat':
-                                                        return Types.TextureWrapMode.Repeat;
-                                                    case 'Clamp':
-                                                        return Types.TextureWrapMode.Clamp;
-                                                    case 'Mirror':
-                                                        return Types.TextureWrapMode.Mirror;
-                                                    default:
-                                                        showDiagnosticAtPosition(`Valid WrapMode options are: 'Clamp', 'Repeat' or 'Mirror'`, endlinePos);
-                                                }
-                                            })();
-                                            
-                                            break;
-                                        default:
-                                            vscode.window.showWarningMessage(`Unkown texture setting '${settingName}', choose either 'MinFilter', 'MagFilter' or 'WrapMode'`);
-                                    }
-
-                                    let texture = textures.find((texture: Types.TextureDefinition) => {
-                                        return texture.Channel === channel;
-                                    });
-                                    if (texture === undefined) {
-                                        texture = pendingTextureSettings.find((texture: Types.TextureDefinition) => {
-                                            return texture.Channel === channel;
-                                        });
-                                    }
-
-                                    let lineInformation = { File: file, Line: getLineNumber(endlinePos) };
-
-                                    if (texture !== undefined) {
-                                        texture.Mag = magFilter || texture.Mag;
-                                        texture.MagLine = magFilter ? lineInformation : undefined;
-                                        texture.Min = minFilter || texture.Min;
-                                        texture.MinLine = minFilter ? lineInformation : undefined;
-                                        texture.Wrap = wrapMode || texture.Wrap;
-                                        texture.WrapLine = wrapMode ? lineInformation : undefined;
-                                    }
-                                    else {
-                                        pendingTextureSettings.push({
-                                            Channel: channel,
-                                            Mag: magFilter || Types.TextureMagFilter.Linear,
-                                            MagLine: magFilter ? lineInformation : undefined,
-                                            Min: minFilter || Types.TextureMinFilter.Linear,
-                                            MinLine: minFilter ? lineInformation : undefined,
-                                            Wrap: wrapMode || Types.TextureWrapMode.Clamp,
-                                            WrapLine: wrapMode ? lineInformation : undefined
-                                        });
-                                    }
-                                }
-                            }
-                        
-                            if (input !== undefined && channel !== undefined) {
-                                // Load the dependency
-                                loadDependency(input, channel, nextMatch.PassType, endlinePos);
-                            }
-                        }
-                    }
-
-                    // Remove #iChannel define
-                    let channelDefine = code.substring(nextMatch.TexturePos, endlinePos - 1);
-                    code = code.replace(channelDefine, '');
-                }
-            }
-        }
-        else {
-            if (this.context.getConfig<boolean>('omitDeprecationWarnings') === false) {
-                vscode.window.showWarningMessage('Loading textures through configuration is deprecated and will be removed in a future version. Please use inline texture definitions.');
-            }
-            let textures: any[] | undefined = this.context.getConfig('textures');
-            if (textures) {
-                for (let i in textures) {
-                    const texture: any = textures[i];
-                    if (texture.length > 0) {
-                        // Check for buffer to load to avoid circular loading
-                        if (this.stripPath(texture) !== this.stripPath(file)) {
-                            loadDependency(texture, parseInt(i), 'iChannel', 0);
-                        }
-                    }
-                }
-            }
-        }
-
-        {
-            let versionPos = code.search(/^#version/g);
-            if (versionPos === 0) {
-                let newLinePos = code.search('\n');
-                let versionDirective = code.substring(versionPos, newLinePos - 1);
-                code = code.replace(versionDirective, '');
-
-                showDiagnosticAtPosition(`Version directive '${versionDirective}' ignored by shader-toy extension`, 0);
-            }
-        }
-
-        // If there is no void main() in the shader we assume it is a shader-toy style shader
-        let mainPos = code.search(/void\s+main\s*\(\s*\)\s*\{/g);
-        let mainImagePos = code.search(/void\s+mainImage\s*\(\s*out\s+vec4\s+\w+,\s*(in\s)?\s*vec2\s+\w+\s*\)\s*\{/g);
-        if (mainPos === -1 && mainImagePos >= 0) {
-            code += `
-            void main() {
-                mainImage(gl_FragColor, gl_FragCoord.xy);
-            }
-            `;
-        }
-
-        // Assign pending texture settings
-        for (let texture of textures) {
-            let pendingSettings = pendingTextureSettings.find((pendingSettings: Types.TextureDefinition) => {
-                return pendingSettings.Channel === texture.Channel;
-            });
-            if (pendingSettings !== undefined) {
-                texture.Mag = pendingSettings.Mag || texture.Mag;
-                texture.MagLine = pendingSettings.MagLine || texture.MagLine;
-                texture.Min = pendingSettings.Min || texture.Min;
-                texture.MinLine = pendingSettings.MinLine || texture.MinLine;
-                texture.Wrap = pendingSettings.Wrap || texture.Wrap;
-                texture.WrapLine = pendingSettings.WrapLine || texture.WrapLine;
-            }
-        }
-
-        // Check if defined textures are used in shader
-        let definedTextures: any = {};
-        for (let texture of textures) {
-            definedTextures[texture.Channel] = true;
-        }
-        for (let audio of audios) {
-            definedTextures[audio.Channel] = true;
-        }
-        if (this.context.getConfig<boolean>('warnOnUndefinedTextures')) {
-            for (let i = 0; i < 9; i++) {
-                if (code.search('iChannel' + i) > 0) {
-                    if (definedTextures[i] === undefined) {
-                        if (useTextureDefinitionInShaders) {
-                            vscode.window.showWarningMessage(`iChannel${i} in use but there is no definition #iChannel${i} in shader`, 'Details')
-                                .then(() => {
-                                    vscode.window.showInformationMessage(`To use this channel add to your shader a line '#iChannel${i}' followed by a space and the path to your texture. Use 'file://' for local textures, 'https://' for remote textures or 'buf://' for other shaders.`);
-                                });
-                        }
-                        else {
-                            vscode.window.showWarningMessage(`iChannel${i} in use but there is no definition '${i}' in settings.json`, 'Details')
-                                .then(() => {
-                                    vscode.window.showInformationMessage(`To use this channel you will need to open your 'settings.json' file and set the option 'shader-toy.textures.${i}' to the path to your texture. Use 'file://' for local textures, 'https://' for remote textures or 'buf://' for other shaders. It is advised to set the option 'shader-toy.textures.useInShaderTextures' to true and define your texture path directly inside your shader.`);
-                                });
-                        }
-                    }
-                }
-            }
-        }
-
-        if (this.context.getConfig<boolean>('enableGlslifySupport')) {
-            // glslify the code
-            var glsl = require('glslify');
-            try {
-                code = glsl(code);
-            }
-            catch(e) {
-                vscode.window.showErrorMessage(e.message);
-            }
-        }
-
-        // Push yourself after all your dependencies
-        buffers.push({
-            Name: this.stripPath(file),
-            File: file,
-            Code: code,
-            Includes: includes,
-            TextureInputs: textures,
-            AudioInputs: audios,
-            CustomUniforms: uniforms,
-            UsesSelf: false,
-            SelfChannel: -1,
-            Dependents: [],
-            UsesKeyboard: usesKeyboard,
-            LineOffset: line_offset
-        });
+        return texture;
     }
 
-    private parseUniformCode(line: string, informationDiagnostic: (message: string) => void): Types.UniformDefinition | undefined {
-        let uniformName = "(missing_uniform_name)";
-        let defaultValue: number[] | undefined;
-        let range: [ number[], number[] ] | undefined;
-        let step: number[] | undefined;
+    private getTextureParameter(index: number): TextureMagFilter | TextureMinFilter | TextureWrapMode | ErrorObject {
+        let nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected texture parameter keyword after "::" but got end-of-file`);
+        }
+        if (nextToken.type !== TokenType.Keyword ||
+            nextToken.value === 'in') {
+            return this.makeError(`Expected texture parameter keyword after "::" but got "${nextToken.value}"`);
+        }
 
-        // TODO: Verify types given, instead of just stripping float, vec2, vec3, vec4, int, ivec2, ivec3, ivec4
+        let textureSetting = nextToken.value as string;
 
-        let inPos = line.indexOf(' in ');
-        if (inPos >= 0) {
-            let rangeString = line.substring(inPos + 4).trim()
-                .replace(/\(/g, '[')
-                .replace(/\)/g, ']')
-                .replace(/float/g, '')
-                .replace(/vec2/g, '')
-                .replace(/vec3/g, '')
-                .replace(/vec4/g, '')
-                .replace(/int/g, '')
-                .replace(/ivec2/g, '')
-                .replace(/ivec3/g, '')
-                .replace(/ivec4/g, '');
-            let rangeDirect: [ number | number[], number | number[] ] = JSON.parse(`{"value": ${rangeString}}`).value;
-            range = [[], []];
-            for (let i of [ 0, 1 ]) {
-                let value = rangeDirect[i];
-                if (Array.isArray(value)) {
-                    range[i] = value;
+        let nextNextToken = this.lexer.next();
+        if (nextNextToken === undefined) {
+            return this.makeError(`Expected string after "${textureSetting}" but got end-of-file`);
+        }
+        if (nextNextToken.type !== TokenType.String) {
+            return this.makeError(`Expected string after "${textureSetting}" but got "${nextNextToken.value}"`);
+        }
+
+        let settingValue = nextNextToken.value as string;
+
+        switch(textureSetting) {
+            case "MagFilter":
+                if (Object.values(Types.TextureMagFilter).includes(settingValue as Types.TextureMagFilter)) {
+                    let magFilter: TextureMagFilter = {
+                        Type: ObjectType.TextureMagFilter,
+                        Index: index,
+                        Value: settingValue as Types.TextureMagFilter
+                    };
+                    return magFilter;
                 }
                 else {
-                    range[i] = [ value ];
+                    return this.makeError(`Expected one of "Nearest" or "Linear" after "${textureSetting}" but got "${settingValue}"`);
                 }
+            case "MinFilter":
+                if (Object.values(Types.TextureMinFilter).includes(settingValue as Types.TextureMinFilter)) {
+                    let minFilter: TextureMinFilter = {
+                        Type: ObjectType.TextureMinFilter,
+                        Index: index,
+                        Value: settingValue as Types.TextureMinFilter
+                    };
+                    return minFilter;
+                }
+                else {
+                    return this.makeError(`Expected one of "Nearest", "NearestMipMapNearest", "NearestMipMapLinear", "Linear", "LinearMipMapNearest" or "LinearMipMapLinear" after "${textureSetting}" but got "${settingValue}"`);
+                }
+            case "WrapMode":
+                if (Object.values(Types.TextureWrapMode).includes(settingValue as Types.TextureWrapMode)) {
+                    let wrapMode: TextureWrapMode = {
+                        Type: ObjectType.TextureWrapMode,
+                        Index: index,
+                        Value: settingValue as Types.TextureWrapMode
+                    };
+                    return wrapMode;
+                }
+                else {
+                    return this.makeError(`Expected one of "Clamp", "Repeat" or "Mirror" after "${textureSetting}" but got "${settingValue}"`);
+                }
+        }
+
+        return this.makeError(`Unkown error while parsing texture setting`);
+    }
+
+    private getUniformObject(): Uniform | ErrorObject {
+        let nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected type after "iUniform" but got end-of-file`);
+        }
+        if (nextToken.type !== TokenType.Type) {
+            return this.makeError(`Expected type after "iUniform" but got "${nextToken.value}"`);
+        }
+
+        let type = nextToken.value as string;
+
+        nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected identifier after "${type}" but got end-of-file`);
+        }
+        if (nextToken.type !== TokenType.Identifier) {
+            return this.makeError(`Expected identifier after "${type}" but got "${nextToken.value}"`);
+        }
+
+        let name = nextToken.value as string;
+
+        let defaultvalue: LiteralNumber | LiteralValue | undefined;
+        let minValue: LiteralNumber | LiteralValue | undefined;
+        let maxValue: LiteralNumber | LiteralValue | undefined;
+
+        nextToken = this.lexer.peek();
+        if (nextToken !== undefined && nextToken.value === "=") {
+            this.lexer.next();
+            let nextValue = this.getValue();
+            if (nextValue.Type === ObjectType.Error) {
+                return nextValue;
+            }
+            defaultvalue = nextValue;
+            if (defaultvalue.ValueType !== type) {
+                return this.makeError(`Expected initializer of type "${type}" but got "${defaultvalue.LiteralString}" which is of type "${defaultvalue.ValueType}"`);
+            }
+            nextToken = this.lexer.peek();
+        }
+        if (nextToken !== undefined && nextToken.value === "in") {
+            this.lexer.next();
+            let rangeArray = this.getArray();
+            
+            if (rangeArray.Type === ObjectType.Error) {
+                return rangeArray;
+            }
+            if (rangeArray.Value.length !== 2) {
+                return this.makeError(`Expected array of type "${type}[2]" but got "${rangeArray.LiteralString}"`);
             }
 
-            line = line.substring(0, inPos).trim();
-        }
-        
-        let equalPos = line.indexOf('=');
-        if (equalPos >= 0) {
-            uniformName = line.substring(0, equalPos).trim();
-            let defaultValueString = line.substring(equalPos + 1).trim()
-                .replace(/\(/g, '[')
-                .replace(/\)/g, ']')
-                .replace(/float/g, '')
-                .replace(/vec2/g, '')
-                .replace(/vec3/g, '')
-                .replace(/vec4/g, '')
-                .replace(/int/g, '')
-                .replace(/ivec2/g, '')
-                .replace(/ivec3/g, '')
-                .replace(/ivec4/g, '');
-            if (defaultValueString.indexOf('[') < 0) {
-                defaultValueString = '[' + defaultValueString + ']';
+            [ minValue, maxValue ] = rangeArray.Value;
+            if (!this.testAssignable(type, minValue.ValueType)) {
+                return this.makeError(`Expected initializer of type "${type}" but got "${minValue.LiteralString}" which is of type ${minValue.ValueType}`);
             }
-
-            defaultValue = JSON.parse(`{"value": ${defaultValueString}}`).value;
-        }
-        else {
-            uniformName = line.trim();
+            if (!this.testAssignable(type, maxValue.ValueType)) {
+                return this.makeError(`Expected initializer of type "${type}" but got "${maxValue.LiteralString}" which is of type ${maxValue.ValueType}`);
+            }
         }
 
-        if (defaultValue !== undefined && range !== undefined) {
-            for (let i of [ 0, 1 ]) {
-                let value = range[i];
-                if (value.length !== defaultValue.length) {
-                    if (value.length !== 1) {
-                        let mismatchType = value.length < defaultValue.length ?
-                            'missing values will be replaced with first value given' :
-                            'redundant values will be removed';
-                        let valueType = i === 0 ? 'minimum' : 'maximum';
-                        informationDiagnostic(`Type mismatch in ${valueType} value, ${mismatchType}.`);
+        let isIntegerType = [ "int", "ivec2", "ivec3", "ivec4" ].findIndex((value: string) => value === type) >= 0; 
+
+        let flattenLiteral = (source: LiteralNumber | LiteralValue | undefined) => {
+            if (source !== undefined) {
+                let flattenRecurse = (source: LiteralNumber | LiteralValue) => {
+                    if (source.Type === ObjectType.Number) {
+                        return [ source.Value ];
                     }
-
-                    for (let j of [ 0, 1, 2, 3 ]) {
-                        if (range[i][j] === undefined) {
-                            range[i][j] = range[i][0];
+                    else {
+                        let result: number[] = [];
+                        for (let value of source.Value) {
+                            result = result.concat(flattenRecurse(value));
                         }
+                        return result;
                     }
+                };
+                return flattenRecurse(source);
+            }
+        };
+
+        let defaultAsNumber = flattenLiteral(defaultvalue);
+        let minValueAsNumber = flattenLiteral(minValue);
+        let maxValueAsNumber = flattenLiteral(maxValue);
+        
+        let uniform: Uniform = {
+            Type: ObjectType.Uniform,
+            Name: name,
+            Typename: type,
+            Default: defaultAsNumber,
+            Min: minValueAsNumber,
+            Max: maxValueAsNumber,
+            Step: isIntegerType ? [ 1.0 ] : undefined
+        };
+        return uniform;
+    }
+
+    private getValue(): LiteralNumber | LiteralValue | ErrorObject {
+        let beginPos = this.stream.pos(); 
+
+        let nextToken = this.lexer.peek();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected a number, a type or '{' but got end-of-file`);
+        }
+        if (nextToken.type !== TokenType.Integer && nextToken.type !== TokenType.Float && nextToken.type !== TokenType.Type && (nextToken.value !== '[' || nextToken.value !== '{')) {
+            return this.makeError(`Expected a number, a type or '{' but got ${nextToken.value}`);
+        }
+
+        if (nextToken.type === TokenType.Integer || nextToken.type === TokenType.Float) {
+            this.lexer.next();
+            let number = nextToken.value as number;
+            let numberObject: LiteralNumber = {
+                Type: ObjectType.Number,
+                ValueType: nextToken.type === TokenType.Integer ? 'int' : 'float',
+                LiteralString: this.stream.code().substring(beginPos, this.stream.pos()).trim(),
+                Value: number
+            };
+            return numberObject;
+        }
+        else if (nextToken.type === TokenType.Type) {
+            this.lexer.next();
+            let type = nextToken.value as string;
+
+            // TODO: Check if type is array type
+
+            let expectedType = type[0] === 'i' ? 'int' : 'float';
+            let expectedSize = parseInt(type[type.length - 1]);
+
+            nextToken = this.lexer.next();
+            if (nextToken === undefined) {
+                return this.makeError(`Expected "(" but got end-of-file`);
+            }
+            if (nextToken.value !== '(') {
+                return this.makeError(`Expected "(" but got ${nextToken.value}`);
+            }
+
+            let firstValue = this.getValue();
+            if (firstValue.Type === ObjectType.Error) {
+                return firstValue;
+            }
+            if (!this.testAssignable(expectedType, firstValue.ValueType)) {
+                return this.makeError(`Expected value assignable to type ${expectedType} but got ${firstValue.LiteralString} which is of type ${firstValue.Type}`);
+            }
+
+            let values: LiteralNumber[] | LiteralValue[] = firstValue.Type === ObjectType.Number ? [ firstValue ] : [ firstValue ];
+
+            for (let i = 1; i < expectedSize; i++) {
+                nextToken = this.lexer.next();
+                if (nextToken === undefined) {
+                    return this.makeError(`Expected "," but got end-of-file`);
+                }
+                if (nextToken.value !== ',') {
+                    return this.makeError(`Expected "," but got "${nextToken.value}"`);
+                }
+
+                let nextValue = this.getValue();
+                if (nextValue.Type === ObjectType.Error) {
+                    return nextValue;
+                }
+                if (!this.testAssignable(expectedType, nextValue.ValueType)) {
+                    return this.makeError(`Expected value assignable to type ${firstValue.ValueType} but got ${nextValue.LiteralString} which is of type ${nextValue.ValueType}`);
+                }
+
+                // Workaround because ts won't recognise values type by itself
+                if (nextValue.Type === ObjectType.Number) {
+                    (values as LiteralNumber[]).push(nextValue);
+                }
+                else {
+                    (values as LiteralValue[]).push(nextValue);
                 }
             }
+
+            nextToken = this.lexer.next();
+            if (nextToken === undefined) {
+                return this.makeError(`Expected ")" but got end-of-file`);
+            }
+            if (nextToken.value !== ')') {
+                return this.makeError(`Expected ")" but got ${nextToken.value}`);
+            }
+
+            let valueObject: LiteralValue = {
+                Type: ObjectType.Value,
+                ValueType: type,
+                LiteralString: this.stream.code().substring(beginPos, this.stream.pos()).trim(),
+                Value: values
+            };
+            return valueObject;
+        }
+        else {
+            return this.getArray();
+        }
+    }
+
+    private getArray(): LiteralValue | ErrorObject {
+        let beginPos = this.stream.pos(); 
+
+        let nextToken = this.lexer.next();
+        if (nextToken === undefined) {
+            return this.makeError(`Expected "{" after "in" but got end-of-file`);
+        }
+        if (nextToken.value !== '[' && nextToken.value !== "{") {
+            return this.makeError(`Expected "{" after "in" but got ${nextToken.value}`);
         }
 
-        if (defaultValue === undefined && range !== undefined) {
-            defaultValue = range[0];
-            informationDiagnostic(`Custom uniform specifies no default value, the minimum of its range will be used.`);
+        let closePunc = nextToken.value === '[' ? ']' : '}';
+
+        let currentValue = this.getValue();
+        if (currentValue.Type === ObjectType.Error) {
+            return currentValue;
         }
 
-        if (defaultValue !== undefined) {
-            if (line.search('int') >= 0 ||
-                line.search('ivec2') >= 0||
-                line.search('ivec3') >= 0||
-                line.search('ivec4') >= 0) {
-                step = Array(defaultValue.length).fill(1);
+        let type = currentValue.ValueType;
+        let values: LiteralNumber[] | LiteralValue[] = currentValue.Type === ObjectType.Number ? [ currentValue ] : [ currentValue ];
+        
+        while (true) {
+            nextToken = this.lexer.next();
+            if (nextToken === undefined) {
+                return this.makeError(`Expected "," or "}" after "${currentValue.LiteralString}" but got end-of-file`);
+            }
+            if (nextToken.value !== "," && nextToken.value !== closePunc) {
+                return this.makeError(`Expected "," or "}" after "${currentValue.LiteralString}" but ${nextToken.value}`);
+            }
+            if (nextToken.value === closePunc) {
+                break;
+            }
+    
+            currentValue = this.getValue();
+            if (currentValue.Type === ObjectType.Error) {
+                return currentValue;
+            }
+            if (!this.testAssignable(type, currentValue.ValueType)) {
+                return this.makeError(`Expected value assignable to type ${type} but got "${currentValue.LiteralString}" which is of type ${currentValue.ValueType}`);
+            }
+
+            // Workaround because ts won't recognise values type by itself
+            if (currentValue.Type === ObjectType.Number) {
+                (values as LiteralNumber[]).push(currentValue);
+            }
+            else {
+                (values as LiteralValue[]).push(currentValue);
             }
         }
 
-        if (defaultValue !== undefined || range !== undefined) {
-            return {
-                Name: uniformName,
-                Default: defaultValue !== undefined ? defaultValue : range !== undefined ? range[0] : [ NaN ],
-                Min: range !== undefined ? range[0] : undefined,
-                Max: range !== undefined ? range[1] : undefined,
-                Step: step
-            };
-        }
-        else {
-            informationDiagnostic(`Custom uniform specifies neither a default value nor a range, it's type can thus not be deduced.`);
+        let valueObject: LiteralValue = {
+            Type: ObjectType.Value,
+            ValueType: `${type}[${values.length}]`,
+            LiteralString: this.stream.code().substring(beginPos, this.stream.pos()).trim(),
+            Value: values
+        };
+        return valueObject;
+    }
+
+    private makeError(message: string): ErrorObject {
+        let lastRange = this.lexer.getLastRange();
+        let error: ErrorObject = {
+            Type: ObjectType.Error,
+            Message: message + `\n${this.lexer.getCurrentLine()}\n  ${' '.repeat(this.stream.column() - lastRange.End + lastRange.Begin)}^^^`
+        };
+        return error;
+    }
+
+    private testAssignable(leftType: string, rightType: string) {
+        if (leftType === rightType) {
+            return true;
         }
 
-        return undefined;
+        if (leftType === 'float' && rightType === 'int') {
+            return true;
+        }
+
+        let lPos = 0;
+        while (leftType[lPos] === rightType[lPos] && leftType[lPos] !== '[') {}
+
+        let isFirst = true;
+
+        let rPos = lPos;
+        while (lPos !== leftType.length && rPos !== rightType.length) {
+            let lStart = lPos + 1;
+            while(leftType[lPos] !== ']') { lPos++; }
+            let lNumber = parseInt(leftType.substring(lStart, lPos - 1));
+
+            let rStart = lPos + 1;
+            while(rightType[rPos] !== ']') { rPos++; }
+            let rNumber = parseInt(rightType.substring(rStart, rPos - 1));
+
+            if (isNaN(lNumber) && isFirst) { continue; }
+
+            if (isNaN(lNumber) || isNaN(rNumber)) { return false; }
+            if (lNumber !== rNumber) { return false; }
+
+            isFirst = false;
+        }
+
+        return lPos === leftType.length && rPos === rightType.length;
     }
 }

--- a/src/shaderparser.ts
+++ b/src/shaderparser.ts
@@ -120,6 +120,7 @@ export class ShaderParser {
                     Type: ObjectType.Keyboard
                 };
                 returnObject = keyboard;
+                break;
             case 'iUniform':
                 returnObject = this.getUniformObject();
                 break;

--- a/src/shaderstream.ts
+++ b/src/shaderstream.ts
@@ -1,0 +1,63 @@
+'use strict';
+
+export class ShaderStream {
+    private content: string;
+    private position: number;
+    private currentLine: number;
+    private currentColumn: number;
+
+    constructor(content: string) {
+        this.content = content;
+        this.position = 0;
+        this.currentLine = 1;
+        this.currentColumn = 0;
+    }
+
+    public reset(content: string, position: number) {
+        this.content = content;
+        this.position = position;
+
+        let preparsedContent = content.substring(0, position).split(/\r\n|\n/);
+        this.currentLine = preparsedContent.length;
+        this.currentColumn = 0;
+        let currentLineBegin = preparsedContent.pop();
+        if (currentLineBegin) {
+            this.currentColumn = this.position - currentLineBegin.length;
+        }
+    }
+
+    public peek(ahead: number = 0): string {
+        return this.content[this.position + ahead];
+    }
+    public next(): string {
+        let ret = this.content[this.position];
+        this.position++;
+        this.currentColumn++;
+        if (ret === '\n' || ret === '\r\n') {
+            this.currentColumn = 0;
+            this.currentLine++;
+        }
+        return ret;
+    }
+    public code(): string {
+        return this.content;
+    }
+    public pos(): number {
+        return this.position;
+    }
+    public line(): number {
+        return this.currentLine;
+    }
+    public column(): number {
+        return this.currentColumn;
+    }
+    public eof(): boolean {
+        return this.position >= this.content.length;
+    }
+
+    public getCurrentLine(): string {
+        let lineFirstHalf = this.content.substring(0, this.position).split(/\r\n|\n/).pop() || '';
+        let lineSecondHalf = this.content.substring(this.position).split(/\r\n|\n/)[0] || '';
+        return lineFirstHalf + lineSecondHalf;
+    }
+}

--- a/src/typenames.ts
+++ b/src/typenames.ts
@@ -20,36 +20,37 @@ export class RenderStartingData {
 
 // Texture setting enums start at 1 so valid settings never implicitly convert to false
 export enum TextureMagFilter {
-    Linear  = 1,
-    Nearest = 2,
+    Linear  = "Linear",
+    Nearest = "Nearest",
 }
 export enum TextureMinFilter {
-    Nearest                 = 1,
-    NearestMipMapNearest    = 2,
-    NearestMipMapLinear     = 3,
-    Linear                  = 4,
-    LinearMipMapNearest     = 5,
-    LinearMipMapLinear      = 6,
+    Nearest                 = "Nearest",
+    NearestMipMapNearest    = "NearestMipMapNearest",
+    NearestMipMapLinear     = "NearestMipMapLinear",
+    Linear                  = "Linear",
+    LinearMipMapNearest     = "LinearMipMapNearest",
+    LinearMipMapLinear      = "LinearMipMapLinear",
 }
 export enum TextureWrapMode {
-    Repeat  = 1,
-    Clamp   = 2,
-    Mirror  = 3,
+    Repeat  = "Repeat",
+    Clamp   = "Clamp",
+    Mirror  = "Mirror",
 }
 
 export type TextureDefinition = {
     Channel: number,
+    File: string,
     Buffer?: string,
     BufferIndex?: number,
     LocalTexture?: string,
     RemoteTexture?: string,
     Self?: boolean,
     Mag?: TextureMagFilter,
-    MagLine?: { File: String, Line: Number },
+    MagLine?: number,
     Min?: TextureMinFilter,
-    MinLine?: { File: String, Line: Number },
+    MinLine?: number,
     Wrap?: TextureWrapMode
-    WrapLine?: { File: String, Line: Number },
+    WrapLine?: number,
 };
 export type AudioDefinition = {
     Channel: number,
@@ -59,6 +60,7 @@ export type AudioDefinition = {
 };
 export type UniformDefinition = {
     Name: string,
+    Typename: string,
     Default: number[],
     Min?: number[],
     Max?: number[],
@@ -67,6 +69,12 @@ export type UniformDefinition = {
 export type BufferDependency = {
     Index: number,
     Channel: number
+};
+export type IncludeDefinition = {
+    Name: string,
+    File: string,
+    Code: string,
+    LineCount: number
 };
 export type BufferDefinition = {
     Name: string,
@@ -79,15 +87,8 @@ export type BufferDefinition = {
     SelfChannel: number,
     Dependents: BufferDependency[],
     LineOffset: number
-    Includes: string[],
+    Includes: IncludeDefinition[],
     UsesKeyboard?: boolean,
-};
-
-export type IncludeDefinition = {
-    Name: string,
-    File: string,
-    Code: string,
-    LineCount: number
 };
 
 export type Diagnostic = {
@@ -98,3 +99,5 @@ export type DiagnosticBatch = {
     filename: string,
     diagnostics: Diagnostic[]
 };
+
+export type BoxedValue<T> = { Value: T };

--- a/src/typenames.ts
+++ b/src/typenames.ts
@@ -11,14 +11,18 @@ export class NormalizedMouse {
     y: number = 0;
 }
 export type Keys = number[];
+export type UniformsGuiStartingData = {
+    Open: boolean;
+    Values: Record<string, number[]>;
+};
 export class RenderStartingData {
     Time: number = 0;
     Mouse: Mouse = new Mouse();
     NormalizedMouse: NormalizedMouse = new NormalizedMouse();
     Keys: Keys = [];
+    UniformsGui: UniformsGuiStartingData = { Open: false, Values: {} };
 }
 
-// Texture setting enums start at 1 so valid settings never implicitly convert to false
 export enum TextureMagFilter {
     Linear  = "Linear",
     Nearest = "Nearest",

--- a/src/webviewcontentprovider.ts
+++ b/src/webviewcontentprovider.ts
@@ -178,7 +178,7 @@ export class WebviewContentProvider {
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Custom Uniforms
         if (useUniforms) {
-            let uniformsInitExtension = new UniformsInitExtension(buffers);
+            let uniformsInitExtension = new UniformsInitExtension(buffers, startingState.UniformsGui);
             this.webviewAssembler.addWebviewModule(uniformsInitExtension, '// Uniforms Init');
             let uniformsUpdateExtension = new UniformsUpdateExtension(buffers);
             this.webviewAssembler.addWebviewModule(uniformsUpdateExtension, '// Uniforms Update');

--- a/src/webviewcontentprovider.ts
+++ b/src/webviewcontentprovider.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import * as Types from './typenames';
-import { ShaderParser } from './shaderparser';
 import { Context } from './context';
+import { BufferProvider } from './bufferprovider';
 import { WebviewContentAssembler } from './webviewcontentassembler';
 import { WebviewExtension } from './extensions/webview_extension';
 
@@ -69,7 +69,6 @@ export class WebviewContentProvider {
     }
 
     public generateWebviewConent(startingState: Types.RenderStartingData): string {
-        let shader = this.documentContent;
         let shaderName = this.documentName;
 
         let webglLineNumbers = 105;
@@ -81,7 +80,8 @@ export class WebviewContentProvider {
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Parse Shaders
         {
-            new ShaderParser(this.context).parseShaderCode(shaderName, shader, buffers, commonIncludes);
+            let shader = this.documentContent;
+            new BufferProvider(this.context).parseShaderCode(shaderName, shader, buffers, commonIncludes);
 
             // If final buffer uses feedback we need to add a last pass that renders it to the screen
             // because we can not ping-pong the screen
@@ -99,6 +99,7 @@ export class WebviewContentProvider {
                         Code: `void main() { gl_FragColor = texture2D(iChannel0, gl_FragCoord.xy / iResolution.xy); }`,
                         TextureInputs: [{
                             Channel: 0,
+                            File: "",
                             Buffer: finalBuffer.Name,
                             BufferIndex: finalBufferIndex,
                         }],
@@ -113,7 +114,6 @@ export class WebviewContentProvider {
                 }
             }
         }
-
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Feature Check


### PR DESCRIPTION
This introduces a proper stream/lexer for GLSL code and our own extensions. The lexer is used in a very rudimentary parser that zeroes in on only our preprocessing features, i.e. textures, uniforms, keyboard and includes.

This was mainly for making the addition of new preprocessing steps in the future less fragile. It also allowed to unify the processing of shaders and include files, thus includes now support all the features that shaders support.

Also adds some other features:
- Removes the need for './' in relative paths
- Allows relative paths from source file rather than only from workspace
- Should reload shaders in all cases of dependencies being changed
- Changed the syntax for custom uniforms (since that is still experimental)
- Keeps the state of the uniform gui and the uniforms themselves across shader reloads

Closes #79 
Closes #80 