### PR TITLE
Fix for numbers with exponents as floats

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2.2.0
 
     - name: Install Node.js
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 10.x
       

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     types: [ created ]
 
 jobs:
-  build:
+  build_and_test:
     name: ${{ matrix.name }}
     
     strategy:
@@ -44,8 +44,3 @@ jobs:
       uses: GabrielBB/xvfb-action@v1.0
       with:
         run: npm test
-    - name: Publish
-      if: success() && startsWith(github.ref, 'refs/tags/releases/') && matrix.os == 'ubuntu-latest'
-      run: npm run deploy
-      env:
-        VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2.2.0
 
     - name: Install Node.js
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 10.x
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,0 +1,44 @@
+name: Publish
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    name: Publish
+    
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.2.0
+
+    - name: Install Node.js
+      uses: actions/setup-node@v1.4.2
+      with:
+        node-version: 10.x
+
+    - name: Wait on tests
+      uses: lewagon/wait-on-check-action@v0.1
+      with:
+        ref: test_publish
+        check-name: Ubuntu
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 20 # seconds
+      
+    - name: Install
+      run: npm install
+      
+    - name: Build
+      run: npm run webpack
+      
+    - name: Publish
+      if: success()
+      run: npm run deploy
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Visual Studio Code - Shader Toy
+<p align="center">
+  <a href="https://github.com/stevensona/shader-toy/actions">
+      <img src="https://github.com/stevensona/shader-toy/workflows/Build%20and%20Test/badge.svg">
+  </a>
+  <a href="https://opensource.org/licenses/MIT" >
+      <img src="https://img.shields.io/apm/l/vim-mode.svg">
+  </a>
+</p>
 
 With this extension, view a live WebGL preview of GLSL shaders within VSCode, similar to [shadertoy.com](https://www.shadertoy.com/) by providing a "Show GLSL Preview" command.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If any of the six files can not be found, the next set is tried, starting from t
 
 ### Audio Input (experimental)
 _Note: By default audio input is disabled, change the setting "Enable Audio Input" to use it._\
-Audio input is only supported from within _Visual Studio Code_, since _ffmpeg_ is not shipped with _Visual Studio Code_
+Audio input is not supported from within _Visual Studio Code_, since _ffmpeg_ is not shipped with _Visual Studio Code_, so you will have to generate a standalone version and host a local server to be able to load local files (or fiddle with your browsers security settings) if you want to use audio in your shaders.
 If your channel defines audio input, it will be inferred from the file extension. The channel will be a `2` pixels high and `512` pixels wide texture, where the width can be adjusted by the "Audio Domain Size" setting. The first row containing the audios frequency spectrum and the second row containing its waveform.
 
 ### Keyboard Input
@@ -166,6 +166,10 @@ Contributions of any kind are welcome and encouraged.
 [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=stevensona.shader-toy)
 
 ## Release Notes
+
+### 0.10.15
+* Lex numbers with exponents as floating point, not integer,
+* make assignability testing more robust.
 
 ### 0.10.14
 * Hotfix, extension was trying to run a non-existant file.

--- a/src/shaderlexer.ts
+++ b/src/shaderlexer.ts
@@ -302,9 +302,6 @@ export class ShaderLexer {
             return return_val;
         });
         let parsedNumber = parseFloat(number);
-        if (parsedNumber === NaN) {
-            console.log(number);
-        }
         return {
             type: has_dot || has_exponent ? TokenType.Float : TokenType.Integer,
             value: parsedNumber

--- a/src/shaderlexer.ts
+++ b/src/shaderlexer.ts
@@ -306,7 +306,7 @@ export class ShaderLexer {
             console.log(number);
         }
         return {
-            type: has_dot ? TokenType.Float : TokenType.Integer,
+            type: has_dot || has_exponent ? TokenType.Float : TokenType.Integer,
             value: parsedNumber
         };
     }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -20,33 +20,33 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
         let lexer = new ShaderLexer(stream);
         
         test("Lex Whole Shader", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'void' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'mainImage' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: '(' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Keyword, value: 'out' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragColor' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Keyword, value: 'in' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec2' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragCoord' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ')' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: '{' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragColor' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Operator, value: '=' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: '(' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: '0.0' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: '0.0' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: '1.0' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: '1.0' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ')' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: ';' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Punctuation, value: '}' });
-            assert.equal(lexer.next(), undefined);
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'void' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'mainImage' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: '(' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Keyword, value: 'out' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragColor' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Keyword, value: 'in' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec2' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragCoord' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ')' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: '{' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'fragColor' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Operator, value: '=' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: '(' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 0.0 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 0.0 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.0 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ',' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.0 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ')' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: ';' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Punctuation, value: '}' });
+            assert.strictEqual(lexer.next(), undefined);
         });
     }
 
@@ -58,16 +58,16 @@ color3// an eof comment`;
         let lexer = new ShaderLexer(stream);
         
         test("Lex Type", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'int' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'float' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec2' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'ivec2' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec3' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'ivec3' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'ivec4' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Type, value: 'color3' });
-            assert.equal(lexer.next(), undefined);
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'int' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'float' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec2' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'ivec2' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec3' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'ivec3' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'vec4' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'ivec4' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Type, value: 'color3' });
+            assert.strictEqual(lexer.next(), undefined);
         });
     }
     
@@ -83,13 +83,13 @@ color3// an eof comment`;
         let lexer = new ShaderLexer(stream);
         
         test("Lex String", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a string' });
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a "string"' });
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a \'string\'' });
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a string' });
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a "string"' });
-            assert.deepEqual(lexer.next(), { type: TokenType.String, value: 'a \'string\'' });
-            assert.equal(lexer.next(), undefined);
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a string' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a "string"' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a \'string\'' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a string' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a "string"' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.String, value: 'a \'string\'' });
+            assert.strictEqual(lexer.next(), undefined);
         });
     }
     
@@ -102,64 +102,64 @@ color3// an eof comment`;
         let lexer = new ShaderLexer(stream);
         
         test("Lex Integers", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
         });
 
         test("Lex Floats", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 999999999999999.999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1. });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 999999999999999.999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1. });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1 });
         });
 
         test("Lex Floats with Exponents", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1.e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1.e-6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1e-6 });
         });
 
         test("Lex Integers with explicit Plus", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
         });
 
         test("Lex Floats with explicit Plus", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 999999999999999.999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1. });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 999999999999999.999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1. });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1 });
         });
 
         test("Lex Floats with explicit Plus with Exponents", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1.e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1.e-6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: .1e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: 1.e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: .1e-6 });
         });
 
         test("Lex negative Integers", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -1 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: -1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: -999999999999999999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -1e-6 });
         });
 
         test("Lex negative Floats", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -999999999999999.999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1. });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -.1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -999999999999999.999999999999999999 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -1. });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -.1 });
         });
 
         test("Lex negative Floats with Exponents", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1.e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1.e-6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -.1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -.1e-6 });
-            assert.equal(lexer.next(), undefined);
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -1.e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -1.e-6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -.1e6 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Float, value: -.1e-6 });
+            assert.strictEqual(lexer.next(), undefined);
         });
     }
 
@@ -170,13 +170,13 @@ aFineVariable aFineVariable_1 a_fine_1_variable __a_fine_var__ 1_a_fine_var_`;
         let lexer = new ShaderLexer(stream);
         
         test("Lex Identifiers", () => {
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'aFineVariable' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'aFineVariable_1' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: 'a_fine_1_variable' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: '__a_fine_var__' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: '1' });
-            assert.deepEqual(lexer.next(), { type: TokenType.Identifier, value: '_a_fine_var_' });
-            assert.equal(lexer.next(), undefined);
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'aFineVariable' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'aFineVariable_1' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: 'a_fine_1_variable' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: '__a_fine_var__' });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
+            assert.deepStrictEqual(lexer.next(), { type: TokenType.Identifier, value: '_a_fine_var_' });
+            assert.strictEqual(lexer.next(), undefined);
         });
     }
 });
@@ -194,7 +194,7 @@ suite("Parsing Tests", () => {
         let parser = new ShaderParser(uniformsContents);
         
         test("Parse Uniforms", () => {
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_float',
                 Typename: 'float',
@@ -203,7 +203,7 @@ suite("Parsing Tests", () => {
                 Max: undefined,
                 Step: undefined
             });
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_float_with_range',
                 Typename: 'float',
@@ -212,7 +212,7 @@ suite("Parsing Tests", () => {
                 Max: [ 1.0 ],
                 Step: undefined
             });
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_vec4',
                 Typename: 'vec4',
@@ -221,7 +221,7 @@ suite("Parsing Tests", () => {
                 Max: undefined,
                 Step: undefined
             });
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_vec4_with_range',
                 Typename: 'vec4',
@@ -230,7 +230,7 @@ suite("Parsing Tests", () => {
                 Max: [ 99.0, 98.0, 97.0, 96.0 ],
                 Step: undefined
             });
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_vec4_with_mismatched_range',
                 Typename: 'vec4',
@@ -239,7 +239,7 @@ suite("Parsing Tests", () => {
                 Max: [ 99.0 ],
                 Step: undefined
             });
-            assert.deepEqual(parser.next(), { 
+            assert.deepStrictEqual(parser.next(), { 
                 Type: ObjectType.Uniform,
                 Name: 'test_color',
                 Typename: 'color3',
@@ -248,7 +248,37 @@ suite("Parsing Tests", () => {
                 Max: undefined,
                 Step: undefined
             });
-            assert.equal(parser.next(), undefined);
+            assert.strictEqual(parser.next(), undefined);
+        });
+    }
+
+    {
+        test("Assignability Tests", () => {
+            let emptyContents = ``;
+            let parser = new ShaderParser(emptyContents);
+            assert.strictEqual(parser['testAssignable']('int', 'int'), true);
+            assert.strictEqual(parser['testAssignable']('float', 'int'), true);
+            assert.strictEqual(parser['testAssignable']('float', 'float'), true);
+
+            assert.strictEqual(parser['testAssignable']('int', 'float'), false);
+
+            assert.strictEqual(parser['testAssignable']('int[]', 'int[]'), true);
+            assert.strictEqual(parser['testAssignable']('int[]', 'int[3]'), true);
+            assert.strictEqual(parser['testAssignable']('int[3]', 'int[3]'), true);
+            assert.strictEqual(parser['testAssignable']('int[3][]', 'int[3][]'), true);
+            assert.strictEqual(parser['testAssignable']('int[3][]', 'int[3][3]'), true);
+            assert.strictEqual(parser['testAssignable']('int[3][3]', 'int[3][3]'), true);
+
+            assert.strictEqual(parser['testAssignable']('float[3][3]', 'int[3][3]'), true);
+
+            assert.strictEqual(parser['testAssignable']('int[2]', 'int[3]'), false);
+            assert.strictEqual(parser['testAssignable']('int[2][2]', 'int[3][2]'), false);
+            assert.strictEqual(parser['testAssignable']('int[][]', 'int[3][2]'), false);
+
+            assert.strictEqual(parser['testAssignable']('int[]', 'int'), false);
+            assert.strictEqual(parser['testAssignable']('int[]', 'float'), false);
+            assert.strictEqual(parser['testAssignable']('float[]', 'float'), false);
+            assert.strictEqual(parser['testAssignable']('float[]', 'int'), false);
         });
     }
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -104,8 +104,8 @@ color3// an eof comment`;
         test("Lex Integers", () => {
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1e-6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
         });
 
         test("Lex Floats", () => {
@@ -124,8 +124,8 @@ color3// an eof comment`;
         test("Lex Integers with explicit Plus", () => {
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1 });
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: 1e-6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: 1e-6 });
         });
 
         test("Lex Floats with explicit Plus", () => {
@@ -144,8 +144,8 @@ color3// an eof comment`;
         test("Lex negative Integers", () => {
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -1 });
             assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -999999999999999999999999999999999 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -1e6 });
-            assert.deepEqual(lexer.next(), { type: TokenType.Integer, value: -1e-6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1e6 });
+            assert.deepEqual(lexer.next(), { type: TokenType.Float, value: -1e-6 });
         });
 
         test("Lex negative Floats", () => {


### PR DESCRIPTION
Also adds better testing of type assignability which fixes the softlock reported in #122

Added two badges to the README (license and CI)
Not sure about the publish CI, but we can merge only the changes to BuildAndTest.yml (formerly CI.yml) which bumps setup-node to fix failing CI